### PR TITLE
requirements: Adding pycairo

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,3 +2,4 @@ cachetools
 numpy
 matplotlib
 redfish
+pycairo


### PR DESCRIPTION
The default rendering engine in hwgraph is cairo, so let's ensure the dependency is explicit to avoid any issue at rendering time.