### PR TITLE
test: ensure every commit in a PR works

### DIFF
--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-
 name: Python check
 
 on:
@@ -11,19 +8,34 @@ on:
 
 jobs:
   build:
-
+    name: Check if every commit in the PR works
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Makefile check
-      run: |
-        make check
+      - name: Compute PR fetch depth
+        shell: bash
+        run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits || 1 }} + 1 ))" >> "${GITHUB_ENV}"
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ env.PR_FETCH_DEPTH }}
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Test every commit in the PR for Python ${{ matrix.python-version }}
+        run: |
+          COMMITS=$(git rev-list ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
+          for commit in $COMMITS; do
+            git checkout $commit || exit 1
+            git show --no-patch --format='Testing commit %h %s'
+            make check || exit 1
+          done


### PR DESCRIPTION
If a pull request contains multiple commits, it is advisable to ensure that every single commit has been tested.

This modifies the python-check workflow to fetch all the commits in the pull request and iteratively run the 'make check' command on each of them. While we are at it, this slighly beautifies the output of the github workflow.