### PR TITLE
Do not run test on direct push

### DIFF
--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -1,8 +1,6 @@
 name: Python check
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
Commit d3105449f303 ("test: ensure every commit in a PR works") ensures that every commit in a pull request is tested. But the way it changes the github action makes it incompatible with being run on direct push.

Since direct push to main are forbidden, it makes sense to disable running tests in this case until a better solution is found.