### PR TITLE
hwbench/tuning: Add specific log entry if tuning is skipped

### DIFF
--- a/hwbench/tuning/power_profile.py
+++ b/hwbench/tuning/power_profile.py
@@ -21,10 +21,11 @@ class PerformancePowerProfile:
         )
 
     def run(self) -> None:
+        log = tunninglog()
         if self.skip_tuning:
+            log.info("skip PerformancePowerProfile as no cpu governor detected")
             return
         pattern = re.compile("cpu[0-9]+")
-        log = tunninglog()
         for rootpath, dirnames, filenames in os.walk("/sys/devices/system/cpu"):
             for dirname in dirnames:
                 if pattern.match(dirname):


### PR DESCRIPTION
When no valid governor configuration is detected, the run() call will skip the tuning.

This skip is silent which could be confusing to understand.

This commit is adding an explicit log entry when the cpu profile tuning is skipped.