### PR TITLE
hwgraph: Do not enable same-chassis feature for a single node

### DIFF
--- a/graph/hwgraph.py
+++ b/graph/hwgraph.py
@@ -195,7 +195,7 @@ def graph_environment(args, output_dir) -> int:
     if chassis:
         all_chassis = [t.get_chassis_serial() == chassis for t in args.traces]
         # if all traces are from the same chassis, let's enable the same_chassis feature
-        if all_chassis.count(True) == len(args.traces):
+        if all_chassis.count(True) == len(args.traces) and len(args.traces) > 1:
             print(
                 f"environment: All traces are from the same chassis ({chassis}), enabling --same-chassis feature"
             )


### PR DESCRIPTION
As per issue#41, when tracing with a single server, the --same-chassis can be engaged generating a crash like:

	~/Devel/hwbench (various)$ python3 -m graph.hwgraph graph --outdir criteo/arno_out --traces ~/Téléchargements/results.json:Arno:BMC.Server
	environment: All traces are from the same chassis (GYLGS63), enabling --same-chassis feature
	Traceback (most recent call last):
	  File "<frozen runpy>", line 198, in _run_module_as_main
	  File "<frozen runpy>", line 88, in _run_code
	  File "/home/e.velu/Devel/hwbench/graph/hwgraph.py", line 380, in <module>
	    main()
	  File "/home/e.velu/Devel/hwbench/graph/hwgraph.py", line 376, in main
	    args.func(args)
	  File "/home/e.velu/Devel/hwbench/graph/hwgraph.py", line 61, in render_traces
	    rendered_graphs += graph_environment(args, output_dir)
			       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/home/e.velu/Devel/hwbench/graph/hwgraph.py", line 234, in graph_environment
	    rendered_graphs += graph_chassis(args, bench_name, output_dir)
			       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/home/e.velu/Devel/hwbench/graph/chassis.py", line 139, in graph_chassis
	    y_serie = np.array(serie[trace.get_name()])[order]
		      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
	IndexError: index 0 is out of bounds for axis 0 with size 0

This commit is adding a new condition to ensure the same-chassis feature is not engaged for a single system.