### PR TITLE
HPE/ilorest: Do not crash if ilorest is missing

### DIFF
--- a/hwbench/environment/vendors/hpe/ilorest.py
+++ b/hwbench/environment/vendors/hpe/ilorest.py
@@ -52,6 +52,8 @@ class ILOREST:
     logged = False
 
     def __init__(self):
+        if not h.is_binary_available("ilorest"):
+            h.fatal("HPE vendor requires 'ilorest' tool, please install it.")
         self.login()
 
     def __del__(self):


### PR DESCRIPTION
If ilorest is not installed on a HPE server, a crash occurs.

This commit is about adding an explicit message to let the user know that ilorest is a mandatory tool for HPE-based systems.

A typical crash calltrace:

Traceback (most recent call last):
  File "/root/hwbench/.venv/bin/hwbench", line 8, in <module>
    sys.exit(main())
  File "/root/hwbench/hwbench/hwbench.py", line 41, in main
    hw = env_hw.Hardware(out_dir, args.monitoring_config)
  File "/root/hwbench/hwbench/environment/hardware.py", line 43, in __init__
    self.vendor = first_matching_vendor(out_dir, self.dmi, monitoring_config)
  File "/root/hwbench/hwbench/environment/vendors/detect.py", line 26, in first_matching_vendor
    v.prepare()
  File "/root/hwbench/hwbench/environment/vendors/hpe/hpe.py", line 211, in prepare
    self.ilo = ILOREST()
  File "/root/hwbench/hwbench/environment/vendors/hpe/ilorest.py", line 55, in __init__
    self.login()
  File "/root/hwbench/hwbench/environment/vendors/hpe/ilorest.py", line 83, in login
    return_code, _ = self.__ilorest("login")
  File "/root/hwbench/hwbench/environment/vendors/hpe/ilorest.py", line 76, in __ilorest
    p = subprocess.Popen(["/usr/sbin/ilorest"] + commands, stdout=subprocess.PIPE)
  File "/usr/lib64/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib64/python3.9/subprocess.py", line 1837, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/usr/sbin/ilorest'