### PR TITLE
hwgraph: Fixing error message

### DIFF
--- a/graph/trace.py
+++ b/graph/trace.py
@@ -201,7 +201,7 @@ class Bench:
         em = self.engine_module()
         # Preparing the performance metric to graph
         if self.engine() not in ["stressng", "sleep"]:
-            fatal(f"Unsupported {em} engine")
+            fatal(f"Unsupported {self.engine()} engine")
         if self.engine() == "stressng":
             if em in ["cpu", "qsort", "vnni"]:
                 perf_list = ["bogo ops/s"]


### PR DESCRIPTION
When hwgraph find an unsupported engine, it prints a message. This message is using the engine module name as the engine name making a confusing output.

This commit use the engine name instead of the engine module.