### PR TITLE
feat: nicely display CPU affinity when running benchmarks

### DIFF
--- a/hwbench/bench/benchmark.py
+++ b/hwbench/bench/benchmark.py
@@ -124,7 +124,9 @@ class ExternalBench(External):
             if isinstance(p.get_pinned_cpu(), (int, str)):
                 cpu_location = " on CPU {:3d}".format(p.get_pinned_cpu())
             elif isinstance(p.get_pinned_cpu(), list):
-                cpu_location = " on CPU {}".format(str(p.get_pinned_cpu()))
+                cpu_location = " on CPU {}".format(
+                    h.cpu_list_to_range(p.get_pinned_cpu())
+                )
             else:
                 h.fatal(
                     "Unsupported get_pinned_cpu() format :{}".format(

--- a/hwbench/utils/helpers.py
+++ b/hwbench/utils/helpers.py
@@ -3,7 +3,7 @@ import logging
 import sys
 from datetime import timedelta
 from shutil import which
-from typing import NoReturn
+from typing import NoReturn, Optional
 
 
 def fatal(message) -> NoReturn:
@@ -30,3 +30,37 @@ def time_to_next_sync(safe_start=True):
 def is_binary_available(binary_name: str) -> bool:
     """A function to check if a binary is available"""
     return which(binary_name) is not None
+
+
+def cpu_list_to_range(cpu_list: list[int]) -> str:
+    """
+    This function takes a list of integers as input and will link them together in a nicely formatted string
+    - `[0, 1, 2, 3, 4, 5]` will give `"0-5"`
+    - `[0, 4, 2, 3, 7, 8, 9]` will give `"0, 2-4, 7-9"`
+
+    It was made specifically for formatting a CPU cores list
+    """
+    cpu_list.sort()
+    output: list[str] = []
+    previous_entry: Optional[int] = cpu_list[0]
+
+    for i in range(1, len(cpu_list)):
+        current_entry = cpu_list[i]
+        is_immediately_next = current_entry - 1 == cpu_list[i - 1]
+        needs_compression = cpu_list[i - 1] != previous_entry
+
+        if not is_immediately_next:
+            if needs_compression:
+                output.append(f"{previous_entry}-{cpu_list[i-1]}")
+            else:
+                output.append(str(previous_entry))
+            previous_entry = current_entry
+
+        # Specifically handle the last entry in the list
+        if i == len(cpu_list) - 1:
+            if cpu_list[i] != previous_entry:
+                output.append(f"{previous_entry}-{current_entry}")
+            else:
+                output.append(str(current_entry))
+
+    return ", ".join(output)

--- a/hwbench/utils/test_helpers.py
+++ b/hwbench/utils/test_helpers.py
@@ -1,0 +1,13 @@
+import unittest
+
+from .helpers import cpu_list_to_range
+
+
+class DisplayHelper(unittest.TestCase):
+    def test_deserialize_cpu_list_to_string(self):
+        "Make sure that the output matches the input even for invalid or weird cases"
+        assert cpu_list_to_range([0, 1, 2, 3, 4, 5]) == "0-5"
+        assert cpu_list_to_range([0, 1, 2, 3, 5]) == "0-3, 5"
+        assert cpu_list_to_range([0, 1, 3, 4, 5]) == "0-1, 3-5"
+        assert cpu_list_to_range([0, 4, 2, 7, 8, 9]) == "0, 2, 4, 7-9"
+        assert cpu_list_to_range([0, 4, 2, 3, 7, 8, 9]) == "0, 2-4, 7-9"


### PR DESCRIPTION
Related to [FEATURE] Improve CPU pinning reporting #49

Previously, when getting information on which CPU the benchmark was running, the string was not intelligently created, leading to really long outputs on CPUs with a lot of cores. Now, we try to be a little smarter:
- [0, 1, 2, 3, 4, 5] becomes "0-5"
- [0, 4, 2, 3, 7, 8, 9] becomes "0, 2-4, 7-9"

It should improve output readability and general UX.