### PR TITLE
benchmark: Fix pinned CPU list display

### DIFF
--- a/hwbench/bench/benchmark.py
+++ b/hwbench/bench/benchmark.py
@@ -124,7 +124,7 @@ class ExternalBench(External):
             if isinstance(p.get_pinned_cpu(), (int, str)):
                 cpu_location = " on CPU {:3d}".format(p.get_pinned_cpu())
             elif isinstance(p.get_pinned_cpu(), list):
-                cpu_location = " on CPU {}".format(
+                cpu_location = " on CPU [{}]".format(
                     h.cpu_list_to_range(p.get_pinned_cpu())
                 )
             else:


### PR DESCRIPTION
Prior commit da6ecdcaa853dfe5b86d3c368ffbcd0a489864fb, the pinned output look like a list like in :

	[randread_cmdline_0] fio/cmdline/cmdline(M):   4 stressor pinned on CPU [0, 1, 2, 3, 4, 5] for 9s

After this commit output looks like:

	[randread_cmdline_0] fio/cmdline/cmdline(M):   4 stressor pinned on CPU 0-5 for 9s

This commit is about adding [] around the string to indicate its a list like in :

	[randread_cmdline_0] fio/cmdline/cmdline(M):   4 stressor pinned on CPU [0-5] for 9s

This will be particulary helpful when the pinned list is composed of several intervals.