### PR TITLE
environment: some CPU vendors might not expose a model name, but use the BIOS model name

### DIFF
--- a/hwbench/environment/cpu_info.py
+++ b/hwbench/environment/cpu_info.py
@@ -60,7 +60,10 @@ class CPU_INFO(External):
         return int(self._mandatory_spec("Model"))
 
     def get_model_name(self) -> str:
-        return self._mandatory_spec("Model name")
+        try:
+            return self._mandatory_spec("Model name")
+        except ValueError as _:
+            return self._mandatory_spec("BIOS Model name")
 
     def get_stepping(self) -> int:
         return int(self._mandatory_spec("Stepping"))


### PR DESCRIPTION
Introduce a fallback so that CPU name detection still works.

Change-Id: If759bd561415eb765ec0e96ce75ec63e4e222ff1