### PR TITLE
vendors: add a generic vendor

### DIFF
--- a/hwbench/environment/vendors/detect.py
+++ b/hwbench/environment/vendors/detect.py
@@ -3,9 +3,9 @@ import pathlib
 from .amd.amd import Amd
 from .dell.dell import Dell
 from .hpe.hpe import Hpe
+from .generic import GenericVendor
 
 from .vendor import Vendor
-from .mock import MockVendor
 from ..dmi import DmiSys
 
 
@@ -13,6 +13,8 @@ VENDOR_LIST = [
     Dell,
     Hpe,
     Amd,
+    # This one always detects the hardware and should be kept at the end
+    GenericVendor,
 ]
 
 
@@ -25,4 +27,4 @@ def first_matching_vendor(
             # If the vendor matched, it may need to prepare some stuff
             v.prepare()
             return v
-    return MockVendor(out_dir, dmi)
+    assert False, "Unreachable: the GenericVendor should have been selected"

--- a/hwbench/environment/vendors/generic.py
+++ b/hwbench/environment/vendors/generic.py
@@ -1,0 +1,30 @@
+from .vendor import Vendor, BMC
+
+
+class GenericVendor(Vendor):
+    def __init__(
+        self,
+        out_dir,
+        dmi,
+        monitoring_config_filename,
+    ):
+        super().__init__(out_dir, dmi, monitoring_config_filename)
+        self.bmc = BMC(self.out_dir, self)
+
+    def detect(self) -> bool:
+        return True
+
+    def save_bios_config(self):
+        print("Warning: using Generic BIOS vendor")
+        # TODO: in the future, dump available BIOS config via redfish
+        # in /redfish/v1/Systems/{system}/Bios
+        self.out_dir.joinpath("generic-bios-config").write_text("")
+
+    def save_bmc_config(self):
+        # TODO: in the future, dump available BMC config via redfish
+        # in /redfish/v1/Systems/{system} and /redfish/v1/Managers/{manager}
+        # different vendors also have different Oem "backup" systems
+        self.out_dir.joinpath("generic-bmc-config").write_text("")
+
+    def name(self) -> str:
+        return "GenericVendor"


### PR DESCRIPTION
We might want to use a generic redfish and PDU interface for some server vendors, or when running from a local machine.

MockVendor stays and should be used exclusively for tests. GenericVendor is when you want to test hwbench locally or on a server of new (yet unsupported) vendor.

Fixes #47 