### PR TITLE
hwbench: generic vendor: make monitoring file optional

### DIFF
--- a/hwbench/environment/vendors/generic.py
+++ b/hwbench/environment/vendors/generic.py
@@ -1,4 +1,5 @@
-from .vendor import BMC, Vendor
+from .mock import MockedBMC
+from .vendor import Vendor
 
 
 class GenericVendor(Vendor):
@@ -9,10 +10,15 @@ class GenericVendor(Vendor):
         monitoring_config_filename,
     ):
         super().__init__(out_dir, dmi, monitoring_config_filename)
-        self.bmc = BMC(self.out_dir, self)
 
     def detect(self) -> bool:
         return True
+
+    def prepare(self):
+        if self.get_monitoring_config_filename():
+            super().prepare()
+        else:
+            self.bmc = MockedBMC(self.out_dir, self)
 
     def save_bios_config(self):
         print("Warning: using Generic BIOS vendor")
@@ -28,3 +34,8 @@ class GenericVendor(Vendor):
 
     def name(self) -> str:
         return "GenericVendor"
+
+    def find_monitoring_sections(self, section_type: str, sections_list=[], max_sections=0):
+        if self.get_monitoring_config_filename():
+            return super().find_monitoring_sections(section_type, sections_list, max_sections)
+        return []


### PR DESCRIPTION
Since we moved to the generic vendor, we no longer use the mockedvendor
by default (it's now only for tests). So when running hwbench on a
desktop/laptop for local testing, it requires setting the monitoring
file, which wasn't the case before.

This change makes the monitoring file optional in this case, with a
fallback when it is not provided to the MockedBMC.