### PR TITLE
github actions: fix installation after move to ubuntu 24.04

### DIFF
--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -24,6 +24,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: ${{ env.PR_FETCH_DEPTH }}
 
+      - name: install cairo so we can install hwgraph dependencies
+        run: sudo apt update && sudo apt install libcairo2-dev
+
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:


### PR DESCRIPTION
The default github action image moved from ubuntu 22.04 to 24.04, and its list of installed packages is not the same. Make sure we have libcairo-dev for pycairo, a dependency of matplotlib used by hwgraph.