### PR TITLE
vendor: remove duplicate find_monitoring_sections in default prepare

### DIFF
--- a/hwbench/environment/vendors/vendor.py
+++ b/hwbench/environment/vendors/vendor.py
@@ -51,7 +51,7 @@ class Vendor(ABC):
     def prepare(self):
         """If the vendor needs some specific code to init itself."""
         if not self.bmc:
-            self.bmc = BMC(self.out_dir, self, self.find_monitoring_sections("BMC"))
+            self.bmc = BMC(self.out_dir, self)
             self.bmc.run()
         if not self.pdus:
             pdu_sections = self.find_monitoring_sections("PDU")


### PR DESCRIPTION
It's now done directly in the BMC class appropriately. We did not find this before because we use the other vendor subclasses which override prepare.