### PR TITLE
README: Explicit SCELNX_64 optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ You can install both of them on the server, but `hwgraph` requires some graphics
 - ipmitool
 - ilorest (for HPE servers)
 - stress-ng >= 0.17.04
+- AMISCE Utility (for some ODM servers) : please contact your hardware vendor to get a copy
 
 ### Requirements to run hwgraph
 #### Mandatory


### PR DESCRIPTION
As per issue #77, let's clarify the optional and
external dependency to SCELNX_64.