### PR TITLE
hwbench/hwgraph: Collect and graph IPC from Turbostat

### DIFF
--- a/graph/hwgraph.py
+++ b/graph/hwgraph.py
@@ -132,6 +132,7 @@ def graph_cpu(args, trace: Trace, bench_name: str, output_dir) -> int:
     cpu_graphs["CPU Core power consumption"] = {Metrics.POWER_CONSUMPTION: "Core"}
     cpu_graphs["Package power consumption"] = {Metrics.POWER_CONSUMPTION: "package"}
     cpu_graphs["Core frequency"] = {Metrics.FREQ: "Core"}
+    cpu_graphs["Core IPC"] = {Metrics.IPC: "Core"}
     for graph_name in cpu_graphs:
         # Let's render the performance, perf_per_temp, perf_per_watt graphs
         for metric, filter in cpu_graphs[graph_name].items():

--- a/hwbench/bench/monitoring.py
+++ b/hwbench/bench/monitoring.py
@@ -3,7 +3,7 @@ from threading import Thread
 from typing import Any
 
 from hwbench.environment.hardware import BaseHardware
-from hwbench.environment.turbostat import Turbostat
+from hwbench.environment.turbostat import CPUSTATS, Turbostat
 from hwbench.utils import helpers as h
 
 from .monitoring_structs import Metrics, MonitoringMetadata, MonitorMetric
@@ -78,8 +78,11 @@ class Monitoring:
                 self.hardware,
                 self.get_metric(Metrics.FREQ),
                 self.get_metric(Metrics.POWER_CONSUMPTION),
+                self.get_metric(Metrics.IPC),
             )
             check_monitoring("turbostat", Metrics.FREQ)
+            if self.turbostat.has(CPUSTATS.IPC):
+                check_monitoring("turbostat", Metrics.IPC)
 
         print(f"Monitoring/BMC: initialize {v.name()} vendor with {bmc.get_driver_name()} {bmc.get_detect_string()}")
 
@@ -249,9 +252,12 @@ class Monitoring:
         self.__set_metric(Metrics.POWER_SUPPLIES, {})
         self.__set_metric(Metrics.THERMAL, {})
         if self.turbostat:
-            freq, power = self.turbostat.reset_metrics({})
+            freq, power, ipc = self.turbostat.reset_metrics({})
             self.__set_metric(Metrics.FREQ, freq)
             self.__set_metric(Metrics.POWER_CONSUMPTION, power)
+            if self.turbostat.has(CPUSTATS.IPC):
+                self.__set_metric(Metrics.IPC, ipc)
         else:
             self.__set_metric(Metrics.FREQ, {})
+            self.__set_metric(Metrics.IPC, {})
         self.__set_metric(Metrics.MONITOR, {})

--- a/hwbench/bench/monitoring_structs.py
+++ b/hwbench/bench/monitoring_structs.py
@@ -107,6 +107,7 @@ class Metrics(Enum):
     THERMAL = "Thermal"
     MONITOR = "Monitor"
     FREQ = "Freq"
+    IPC = "IPC"
 
     def __str__(self) -> str:
         return str(self.value)


### PR DESCRIPTION
As per issue #79, it is very interesting to collect and graph IPC.

IPC (Instructions Per Cycle) indicate the number of instructions the CPU has been able to process per each clock cycle.

Reporting and graphing this number could help determining the efficiency of a given CPU.