### PR TITLE
block_devices: fix bytes conversion in export

### DIFF
--- a/hwbench/environment/block_devices.py
+++ b/hwbench/environment/block_devices.py
@@ -79,8 +79,8 @@ class Block_Device:
         for attribute in attributes.available_attributes:
             # The casting below is to avoid breaking struct to json. b"" cant be serialized has to be cast as string
             dumped[attribute] = (
-                str(attributes.get(attribute))
-                if type(attributes.get(attribute)) is bytes
+                attributes.get(attribute).decode()
+                if isinstance(attributes.get(attribute), bytes)
                 else attributes.get(attribute)
             )
         return dumped


### PR DESCRIPTION
It seems udev_attributes from block devices were all containing "b'value'" which indicates a bad string conversion from bytes. This is now fixed and should resolve #87