### PR TITLE
ux: crash early if a binary is not available, and display all the missing ones

### DIFF
--- a/hwbench/bench/test_benchmarks.py
+++ b/hwbench/bench/test_benchmarks.py
@@ -13,7 +13,6 @@ class TestParse(tbc.TestCommon):
         # We need to patch list_module_parameters() function
         # to avoid considering the local stress-ng binary
         with patch("hwbench.engines.stressng_cpu.EngineModuleCpu.list_module_parameters") as p:
-            print(pathlib.Path("."))
             p.return_value = (
                 pathlib.Path("hwbench/tests/parsing/stressngmethods/v17/stdout").read_bytes().split(b":", 1)
             )

--- a/hwbench/bench/test_benchmarks_common.py
+++ b/hwbench/bench/test_benchmarks_common.py
@@ -51,8 +51,10 @@ class TestCommon(unittest.TestCase):
 
     def load_benches(self, jobs_config_file: str):
         """Turn jobs_config_file into benchmarks"""
-        self.jobs_config = config.Config(jobs_config_file, self.hw)
-        self.benches = benchmarks.Benchmarks(".", self.jobs_config, self.hw)
+        self.jobs_config = config.Config(jobs_config_file)
+        self.jobs_config.set_hardware(self.hw)
+        self.benches = benchmarks.Benchmarks(".", self.jobs_config)
+        self.benches.set_hardware(self.hw)
 
     def get_bench_parameters(self, index):
         """Return the benchmark parameters."""
@@ -63,17 +65,15 @@ class TestCommon(unittest.TestCase):
 
     def parse_jobs_config(self, validate_parameters=True):
         # We need to mock turbostat when parsing config with monitoring
-        with patch("hwbench.utils.helpers.is_binary_available") as iba:
-            iba.return_value = True
-            # We mock the run() and check_version() command to get a constant output
-            with patch("hwbench.environment.turbostat.Turbostat.check_version") as cv:
-                cv.return_value = True
-                with (
-                    patch("hwbench.environment.turbostat.Turbostat.run") as ts,
-                    open("hwbench/tests/parsing/turbostat/run") as f,
-                ):
-                    ts.return_value = ast.literal_eval(f.read())
-                    return self.benches.parse_jobs_config(validate_parameters)
+        # We mock the run() and check_version() command to get a constant output
+        with patch("hwbench.environment.turbostat.Turbostat.check_version") as cv:
+            cv.return_value = True
+            with (
+                patch("hwbench.environment.turbostat.Turbostat.run") as ts,
+                open("hwbench/tests/parsing/turbostat/run") as f,
+            ):
+                ts.return_value = ast.literal_eval(f.read())
+                return self.benches.parse_jobs_config(validate_parameters)
 
     def get_jobs_config(self) -> config.Config:
         return self.jobs_config

--- a/hwbench/config/config.py
+++ b/hwbench/config/config.py
@@ -14,7 +14,7 @@ from . import config_syntax
 
 
 class Config:
-    def __init__(self, jobs_file: str, hardware: env_hw.Hardware):
+    def __init__(self, jobs_file: str):
         self.jobs_file = jobs_file
         if not os.path.isfile(self.jobs_file):
             h.fatal(f"File '{self.jobs_file}' does not exists.")
@@ -32,7 +32,6 @@ class Config:
             "sync_start": "none",
         }
         self.jobs_config = configparser.RawConfigParser(default_section="global", defaults=default_parameters)
-        self.hardware = hardware
         self.jobs_config.read(self.jobs_file)
 
     def to_dict(self) -> dict:
@@ -41,6 +40,14 @@ class Config:
             items = self.jobs_config.items(section)
             output_dict[section] = dict(items)
         return output_dict
+
+    def set_hardware(self, hardware: env_hw.Hardware):
+        self.hardware = hardware
+
+    def get_hardware(self) -> env_hw.Hardware:
+        if self.hardware is None:
+            raise AttributeError("Hardware has not been previously set")
+        return self.hardware
 
     def get_sections(self) -> list[str]:
         """Return all sections of a config file."""

--- a/hwbench/config/config_syntax.py
+++ b/hwbench/config/config_syntax.py
@@ -29,6 +29,7 @@ def validate_engine_module(config, section_name, value) -> str:
     """Validate the engine module syntax."""
     try:
         engine = config.load_engine(config.get_engine(section_name))
+        engine.init()
     except ModuleNotFoundError:
         return f'Unknown "{value}" engine'
     if not engine.module_exists(value):
@@ -42,6 +43,7 @@ def validate_engine_module_parameter(config, section_name, value) -> str:
     """Validate the engine module parameter syntax."""
     try:
         engine = config.load_engine(config.get_engine(section_name))
+        engine.init()
     except ModuleNotFoundError:
         return f'Unknown "{value}" engine'
     engine_module_name = config.get_engine_module(section_name)

--- a/hwbench/engines/stressng_cpu.py
+++ b/hwbench/engines/stressng_cpu.py
@@ -25,6 +25,8 @@ class EngineModuleCpu(EngineModulePinnable):
     def __init__(self, engine: EngineBase, engine_module_name: str):
         super().__init__(engine, engine_module_name)
         self.engine_module_name = engine_module_name
+
+    def init(self):
         self.load_module_parameter()
 
     def list_module_parameters(self):

--- a/hwbench/engines/test_parse_stressng.py
+++ b/hwbench/engines/test_parse_stressng.py
@@ -24,7 +24,9 @@ def mock_engine(version: str) -> StressNG:
             p.return_value = (
                 pathlib.Path(f"./hwbench/tests/parsing/stressngmethods/{version}/stdout").read_bytes().split(b":", 1)
             )
-            return StressNG()
+            stress_ng = StressNG()
+            stress_ng.init()
+            return stress_ng
 
 
 class TestParse(unittest.TestCase):

--- a/hwbench/environment/hardware.py
+++ b/hwbench/environment/hardware.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import pathlib
 from abc import abstractmethod
 
+from hwbench.utils import helpers
 from hwbench.utils.external import External_Simple
+from hwbench.utils.helpers import MissingBinary
 
 from .base import BaseEnvironment
 from .block_devices import Block_Devices
@@ -13,6 +15,18 @@ from .lspci import Lspci, LspciBin
 from .nvme import Nvme
 from .vendors.detect import first_matching_vendor
 from .vendors.vendor import Vendor
+
+
+def check_requirements() -> list[Exception]:
+    """Check if all required binaries are available
+    This is a "better than nothing" solution, as the current codebase
+    does not yet properly support detecting all required binaries.
+    """
+    problems: list[Exception] = []
+    for binary in ["lspci", "ipmitool", "dmidecode", "nvme", "smartctl", "sdparm"]:
+        if not helpers.is_binary_available(binary):
+            problems.append(MissingBinary(binary))
+    return problems
 
 
 # This is the interface of Hardware

--- a/hwbench/utils/helpers.py
+++ b/hwbench/utils/helpers.py
@@ -8,6 +8,14 @@ from shutil import which
 from typing import NoReturn
 
 
+class MissingBinary(Exception):
+    def __init__(self, binary):
+        self.binary = binary
+
+    def __str__(self):
+        return f"Binary {self.binary} is not available on the system"
+
+
 def fatal(message) -> NoReturn:
     logging.error(message)
     sys.exit(1)


### PR DESCRIPTION
This should make the entry into the hwbench world easier. Now, instead of crashing once and for all if something is missing, it will collect everything missing, and then stop. This system can be easily expanded to add other kind of requirements.

For instance, it returns this when I'm missing those binaries:
```
CRITICAL:root:Requirements are not met: Binary smartctl is not available on the system
CRITICAL:root:Requirements are not met: Binary sdparm is not available on the system
CRITICAL:root:Requirements are not met: Binary stress-ng is not available on the system
CRITICAL:root:Requirements are not met: Binary fio is not available on the system
```