### PR TITLE
engines: fix version checks

### DIFF
--- a/hwbench/bench/engine.py
+++ b/hwbench/bench/engine.py
@@ -54,6 +54,7 @@ class EngineBase(External):
         self.engine_name = name
         self.binary = binary
         self.modules = modules
+        self.version = ""
 
     def get_binary(self) -> str:
         return self.binary
@@ -85,3 +86,6 @@ class EngineBase(External):
 
     def module_exists(self, module_name) -> bool:
         return module_name in self.modules
+
+    def get_version(self) -> str:
+        return self.version

--- a/hwbench/engines/fio.py
+++ b/hwbench/engines/fio.py
@@ -5,7 +5,7 @@ from typing import Any
 from hwbench.bench.benchmark import ExternalBench
 from hwbench.bench.engine import EngineBase, EngineModuleBase
 from hwbench.bench.parameters import BenchmarkParameters
-from hwbench.utils.helpers import fatal
+from hwbench.utils.helpers import fatal, versiontuple
 
 
 class EngineModuleCmdline(EngineModuleBase):
@@ -51,19 +51,12 @@ class Engine(EngineBase):
     def run_cmd(self) -> list[str]:
         return []
 
-    def parse_version(self, stdout: bytes, _stderr: bytes) -> bytes:
-        self.version = stdout.split(b"-")[1].strip()
+    def parse_version(self, stdout: bytes, _stderr: bytes) -> str:
+        self.version = stdout.split(b"-")[1].strip().decode()
         return self.version
 
-    def version_major(self) -> int:
-        if self.version:
-            return int(self.version.split(b".")[0])
-        return 0
-
-    def version_minor(self) -> int:
-        if self.version:
-            return int(self.version.split(b".")[1])
-        return 0
+    def get_version(self):
+        return self.version
 
     def parse_cmd(self, stdout: bytes, stderr: bytes):
         return {}
@@ -84,7 +77,7 @@ class Fio(ExternalBench):
 
     def version_compatible(self) -> bool:
         engine = self.engine_module.get_engine()
-        return engine.version_major() >= 3 and engine.version_minor() >= 19
+        return versiontuple(engine.get_version()) >= versiontuple("3.19")
 
     def _parse_parameters(self):
         self.runtime = self.parameters.runtime
@@ -181,7 +174,7 @@ class Fio(ExternalBench):
     def run_cmd_version(self) -> list[str]:
         return self.engine_module.get_engine().run_cmd_version()
 
-    def parse_version(self, stdout: bytes, _stderr: bytes) -> bytes:
+    def parse_version(self, stdout: bytes, _stderr: bytes) -> str:
         return self.engine_module.get_engine().parse_version(stdout, _stderr)
 
     def empy_result(self):

--- a/hwbench/engines/sleep.py
+++ b/hwbench/engines/sleep.py
@@ -41,14 +41,9 @@ class Engine(EngineBase):
     def run_cmd(self) -> list[str]:
         return []
 
-    def parse_version(self, stdout: bytes, _stderr: bytes) -> bytes:
-        self.version = stdout.split()[3]
+    def parse_version(self, stdout: bytes, _stderr: bytes) -> str:
+        self.version = stdout.split()[3].decode()
         return self.version
-
-    def version_major(self) -> int:
-        if self.version:
-            return int(self.version.split(b".")[1])
-        return 0
 
     def parse_cmd(self, stdout: bytes, stderr: bytes):
         return {}
@@ -83,5 +78,5 @@ class Sleep(ExternalBench):
     def run_cmd_version(self) -> list[str]:
         return self.engine_module.get_engine().run_cmd_version()
 
-    def parse_version(self, stdout: bytes, _stderr: bytes) -> bytes:
+    def parse_version(self, stdout: bytes, _stderr: bytes) -> str:
         return self.engine_module.get_engine().parse_version(stdout, _stderr)

--- a/hwbench/engines/spike.py
+++ b/hwbench/engines/spike.py
@@ -54,14 +54,9 @@ class Engine(EngineBase):
     def run_cmd(self) -> list[str]:
         return []
 
-    def parse_version(self, stdout: bytes, _stderr: bytes) -> bytes:
-        self.version = stdout.split()[3]
+    def parse_version(self, stdout: bytes, _stderr: bytes) -> str:
+        self.version = stdout.split()[3].decode()
         return self.version
-
-    def version_major(self) -> int:
-        if self.version:
-            return int(self.version.split(b".")[1])
-        return 0
 
     def parse_cmd(self, stdout: bytes, stderr: bytes):
         return {}
@@ -289,5 +284,5 @@ class Spike(ExternalBench):
     def run_cmd_version(self) -> list[str]:
         return self.engine_module.get_engine().run_cmd_version()
 
-    def parse_version(self, stdout: bytes, _stderr: bytes) -> bytes:
+    def parse_version(self, stdout: bytes, _stderr: bytes) -> str:
         return self.engine_module.get_engine().parse_version(stdout, _stderr)

--- a/hwbench/engines/stressng.py
+++ b/hwbench/engines/stressng.py
@@ -37,7 +37,7 @@ class Engine(EngineBase):
         self.add_module(EngineModuleStream(self, "stream"))
         self.add_module(EngineModuleMemrate(self, "memrate"))
         self.add_module(EngineModuleVNNI(self, "vnni"))
-        self.version = None
+        self.version = ""
 
     def run_cmd_version(self) -> list[str]:
         return [
@@ -48,14 +48,12 @@ class Engine(EngineBase):
     def run_cmd(self) -> list[str]:
         return []
 
-    def parse_version(self, stdout: bytes, _stderr: bytes) -> bytes:
-        self.version = stdout.split()[2]
+    def parse_version(self, stdout: bytes, _stderr: bytes) -> str:
+        self.version = stdout.split()[2].decode()
         return self.version
 
-    def get_version(self) -> str | None:
-        if self.version:
-            return self.version.decode("utf-8")
-        return None
+    def get_version(self) -> str:
+        return self.version
 
     def parse_cmd(self, stdout: bytes, stderr: bytes):
         return {}
@@ -104,7 +102,7 @@ class StressNG(ExternalBench):
     def name(self) -> str:
         return self.engine_module.get_engine().get_name() + self.stressor_name
 
-    def parse_version(self, stdout: bytes, _stderr: bytes) -> bytes:
+    def parse_version(self, stdout: bytes, _stderr: bytes) -> str:
         return self.engine_module.get_engine().parse_version(stdout, _stderr)
 
     def run_cmd_version(self) -> list[str]:

--- a/hwbench/engines/test_parse_fio.py
+++ b/hwbench/engines/test_parse_fio.py
@@ -2,6 +2,8 @@ import pathlib
 import unittest
 from unittest.mock import patch
 
+from hwbench.utils.helpers import versiontuple
+
 from .fio import Engine as Fio
 
 
@@ -21,6 +23,5 @@ class TestParse(unittest.TestCase):
             ver_stdout = (d / "version-stdout").read_bytes()
             ver_stderr = (d / "version-stderr").read_bytes()
             version = test_target.parse_version(ver_stdout, ver_stderr)
-            assert version == (d / "version").read_bytes().strip()
-            assert test_target.version_major() == 3
-            assert test_target.version_minor() == 19
+            assert version == (d / "version").read_text().strip()
+            assert versiontuple(test_target.get_version()) == versiontuple("3.19")

--- a/hwbench/engines/test_parse_stressng.py
+++ b/hwbench/engines/test_parse_stressng.py
@@ -39,7 +39,7 @@ class TestParse(unittest.TestCase):
             ver_stdout = (d / "version-stdout").read_bytes()
             ver_stderr = (d / "version-stderr").read_bytes()
             version = test_target.parse_version(ver_stdout, ver_stderr)
-            assert version == (d / "version").read_bytes().strip()
+            assert version == (d / "version").read_text().strip()
 
     def test_module_parsing_output(self):
         engine_v17 = mock_engine("v17")

--- a/hwbench/environment/block_devices.py
+++ b/hwbench/environment/block_devices.py
@@ -152,13 +152,13 @@ class Smartctl(External):
     def run_cmd_version(self) -> list[str]:
         return ["smartctl", "-j", "--version"]
 
-    def parse_version(self, stdout: bytes, stderr: bytes) -> bytes:
+    def parse_version(self, stdout: bytes, stderr: bytes) -> str:
         try:
             data = loads(stdout)
         except JSONDecodeError:
             h.fatal(stdout)
         self.version = ".".join(str(x) for x in data["smartctl"]["version"])
-        return str.encode(self.version)
+        return self.version
 
     def dump(self) -> dict[str, Any]:
         self.run()
@@ -173,7 +173,7 @@ class Sdparm(External):
         self.cmd_name = "sdparm"
         self.out_dir = out_dir
         self.data: dict[str, dict[str, Any]] = {}
-        self.version = b""
+        self.version = ""
 
     @property
     def name(self) -> str:
@@ -221,9 +221,9 @@ class Sdparm(External):
     def run_cmd_version(self) -> list[str]:
         return ["sdparm", "--version"]
 
-    def parse_version(self, stdout: bytes, stderr: bytes) -> bytes:
+    def parse_version(self, stdout: bytes, stderr: bytes) -> str:
         if stderr:
-            self.version = stderr.split()[1]
+            self.version = stderr.split()[1].decode()
         return self.version
 
     def dump(self) -> dict[str, dict[str, Any]]:

--- a/hwbench/environment/cpu_cores.py
+++ b/hwbench/environment/cpu_cores.py
@@ -24,9 +24,9 @@ class CPU_CORES(External):
     def run_cmd_version(self) -> list[str]:
         return ["lscpu", "--version"]
 
-    def parse_version(self, stdout: bytes, _stderr: bytes) -> bytes:
+    def parse_version(self, stdout: bytes, _stderr: bytes) -> str:
         """Return the version of lscpu"""
-        return stdout.split()[3]
+        return stdout.split()[3].decode()
 
     @property
     def name(self) -> str:

--- a/hwbench/environment/cpu_info.py
+++ b/hwbench/environment/cpu_info.py
@@ -22,9 +22,9 @@ class CPU_INFO(External):
     def run_cmd_version(self) -> list[str]:
         return ["lscpu", "--version"]
 
-    def parse_version(self, stdout: bytes, _stderr: bytes) -> bytes:
+    def parse_version(self, stdout: bytes, _stderr: bytes) -> str:
         """Return the version of lscpu"""
-        return stdout.split()[3]
+        return stdout.split()[3].decode()
 
     @property
     def name(self) -> str:

--- a/hwbench/environment/dmi.py
+++ b/hwbench/environment/dmi.py
@@ -57,9 +57,9 @@ class DmidecodeRaw(External):
     def run_cmd_version(self) -> list[str]:
         return ["dmidecode", "--version"]
 
-    def parse_version(self, stdout: bytes, _stderr: bytes) -> bytes:
+    def parse_version(self, stdout: bytes, _stderr: bytes) -> str:
         """Not much to parse since the full output is the version with dmidecode"""
-        return stdout.strip()
+        return stdout.strip().decode()
 
     @property
     def name(self) -> str:

--- a/hwbench/environment/lspci.py
+++ b/hwbench/environment/lspci.py
@@ -12,8 +12,8 @@ class Lspci(External):
     def run_cmd_version(self) -> list[str]:
         return ["lspci", "--version"]
 
-    def parse_version(self, stdout: bytes, _stderr: bytes) -> bytes:
-        self.version = stdout.split()[2]
+    def parse_version(self, stdout: bytes, _stderr: bytes) -> str:
+        self.version = stdout.split()[2].decode()
         return self.version
 
     @property

--- a/hwbench/environment/numa.py
+++ b/hwbench/environment/numa.py
@@ -45,8 +45,8 @@ class NUMA(External):
     def run_cmd_version(self) -> list[str]:
         return []
 
-    def parse_version(self, stdout: bytes, _stderr: bytes) -> bytes:
-        return b""
+    def parse_version(self, stdout: bytes, _stderr: bytes) -> str:
+        return ""
 
     @property
     def name(self) -> str:

--- a/hwbench/environment/nvme.py
+++ b/hwbench/environment/nvme.py
@@ -12,8 +12,8 @@ class Nvme(External):
     def run_cmd_version(self) -> list[str]:
         return ["nvme", "version"]
 
-    def parse_version(self, stdout: bytes, _stderr: bytes) -> bytes:
-        self.version = stdout.split()[2]
+    def parse_version(self, stdout: bytes, _stderr: bytes) -> str:
+        self.version = stdout.split()[2].decode()
         return self.version
 
     @property

--- a/hwbench/environment/packages.py
+++ b/hwbench/environment/packages.py
@@ -12,8 +12,8 @@ class RpmList(External):
     def run_cmd_version(self) -> list[str]:
         return ["rpm", "--version"]
 
-    def parse_version(self, stdout: bytes, _stderr: bytes) -> bytes:
-        self.version = stdout.split()[2]
+    def parse_version(self, stdout: bytes, _stderr: bytes) -> str:
+        self.version = stdout.split()[2].decode()
         return self.version
 
     @property

--- a/hwbench/environment/test_parse.py
+++ b/hwbench/environment/test_parse.py
@@ -16,7 +16,7 @@ class TestParseCPU:
         ver_stdout = (d / "version-stdout").read_bytes()
         ver_stderr = (d / "version-stderr").read_bytes()
         version = test_target.parse_version(ver_stdout, ver_stderr)
-        assert version == (d / "version").read_bytes().strip()
+        assert version == (d / "version").read_text().strip()
 
     def test_parsing_cpuinfo(self):
         for d in [
@@ -30,7 +30,7 @@ class TestParseCPU:
             ver_stderr = (d / "version-stderr").read_bytes()
 
             version = test_target.parse_version(ver_stdout, ver_stderr)
-            assert version == (d / "version").read_bytes().strip()
+            assert version == (d / "version").read_text().strip()
 
             stdout = (d / "stdout").read_bytes()
             stderr = (d / "stderr").read_bytes()
@@ -59,7 +59,7 @@ class TestParseCPU:
             ver_stderr = (d / "version-stderr").read_bytes()
 
             version = test_target.parse_version(ver_stdout, ver_stderr)
-            assert version == (d / "version").read_bytes().strip()
+            assert version == (d / "version").read_text().strip()
 
             stdout = (d / "stdout").read_bytes()
             stderr = (d / "stderr").read_bytes()
@@ -164,7 +164,7 @@ class TestParseNvme:
         ver_stderr = (d / "version-stderr").read_bytes()
 
         version = test_target.parse_version(ver_stdout, ver_stderr)
-        assert version == (d / "version").read_bytes().strip()
+        assert version == (d / "version").read_text().strip()
 
 
 class TestParseSdparm:
@@ -178,7 +178,7 @@ class TestParseSdparm:
         ver_stderr = (self.d / "version-stderr").read_bytes()
 
         version = self.test_target.parse_version(ver_stdout, ver_stderr)
-        assert version == (self.d / "version").read_bytes().strip()
+        assert version == (self.d / "version").read_text().strip()
 
     def test_parsing_sdparm_stdout_stderr(self):
         print(f"parsing test {self.d.name}")
@@ -202,7 +202,7 @@ class TestParseSMART:
         ver_stderr = (self.d / "version-stderr").read_bytes()
 
         version = self.test_target.parse_version(ver_stdout, ver_stderr)
-        assert version == (self.d / "version").read_bytes().strip()
+        assert version == (self.d / "version").read_text().strip()
 
     def test_parsing_smartctl_stdout_stderr(self):
         print(f"parsing test {self.d.name}")

--- a/hwbench/environment/vendors/amd/ami_aptio.py
+++ b/hwbench/environment/vendors/amd/ami_aptio.py
@@ -19,15 +19,15 @@ class Ami_Aptio(External):
     def run_cmd_version(self) -> list[str]:
         return ["EtaSceLnx64"]
 
-    def parse_version(self, _stdout: bytes, stderr: bytes) -> bytes:
-        self.version = b""
+    def parse_version(self, _stdout: bytes, stderr: bytes) -> str:
+        self.version = ""
         for line in stderr.decode("utf-8").splitlines():
             if not line:
                 continue
             # |                   AMISCE Utility. Ver 5.05.05.0006.2301             |
             match = re.search(r".*AMISCE Utility. Ver (?P<version>[0-9.]+).*$", line)
             if match:
-                self.version = bytes(match.group("version"), encoding="utf-8")
+                self.version = match.group("version")
                 break
         return self.version
 

--- a/hwbench/environment/vendors/bmc.py
+++ b/hwbench/environment/vendors/bmc.py
@@ -46,8 +46,8 @@ class BMC(MonitoringDevice, External):
     def run_cmd_version(self) -> list[str]:
         return ["ipmitool", "-V"]
 
-    def parse_version(self, stdout: bytes, _stderr: bytes) -> bytes:
-        self.version = stdout.split()[2]
+    def parse_version(self, stdout: bytes, _stderr: bytes) -> str:
+        self.version = stdout.split()[2].decode()
         return self.version
 
     @property

--- a/hwbench/environment/vendors/hpe/ilorest.py
+++ b/hwbench/environment/vendors/hpe/ilorest.py
@@ -18,8 +18,8 @@ class Ilorest(External):
     def run_cmd_version(self) -> list[str]:
         return ["ilorest", "--version"]
 
-    def parse_version(self, stdout: bytes, _stderr: bytes) -> bytes:
-        self.version = stdout.split()[3]
+    def parse_version(self, stdout: bytes, _stderr: bytes) -> str:
+        self.version = stdout.split()[3].decode()
         return self.version
 
     @property
@@ -38,8 +38,8 @@ class IlorestServerclone(External):
     def run_cmd_version(self) -> list[str]:
         return ["ilorest", "--version"]
 
-    def parse_version(self, stdout: bytes, _stderr: bytes) -> bytes:
-        self.version = stdout.split()[3]
+    def parse_version(self, stdout: bytes, _stderr: bytes) -> str:
+        self.version = stdout.split()[3].decode()
         return self.version
 
     @property

--- a/hwbench/utils/external.py
+++ b/hwbench/utils/external.py
@@ -30,8 +30,8 @@ class External(ABC):
         return {}
 
     @abstractmethod
-    def parse_version(self, stdout: bytes, stderr: bytes) -> bytes:
-        return b""
+    def parse_version(self, stdout: bytes, stderr: bytes) -> str:
+        return ""
 
     def _write_output(self, name: str, content: bytes):
         if len(content) > 0:
@@ -88,8 +88,8 @@ class External_Simple(External):
     def run_cmd(self) -> list[str]:
         return self.cmd_list
 
-    def parse_version(self, stdout: bytes, _stderr: bytes) -> bytes:
-        return b""
+    def parse_version(self, stdout: bytes, _stderr: bytes) -> str:
+        return ""
 
     def parse_cmd(self, stdout: bytes, stderr: bytes):
         return {}


### PR DESCRIPTION
We ensure that all the versions are checked properly everywhere. We also standardized the version methods to make them easier to implement while documenting the type itself.