### PR TITLE
monitor all power control elements

### DIFF
--- a/hwbench/bench/monitoring.py
+++ b/hwbench/bench/monitoring.py
@@ -92,6 +92,9 @@ class Monitoring:
         self.vendor.get_bmc().read_power_consumption(self.metrics.contexts.PowerConsumption)
         check_monitoring("BMC", MonitoringContextKeys.PowerConsumption, self.metrics.contexts.PowerConsumption)
 
+        self.vendor.get_bmc().read_oob_power_consumption(self.metrics.contexts.PowerConsumption)
+        check_monitoring("BMC", MonitoringContextKeys.PowerConsumption, self.metrics.contexts.PowerConsumption)
+
         self.vendor.get_bmc().read_power_supplies(self.metrics.contexts.PowerSupplies)
         check_monitoring("BMC", MonitoringContextKeys.PowerSupplies, self.metrics.contexts.PowerSupplies)
 
@@ -132,6 +135,7 @@ class Monitoring:
         self.vendor.get_bmc().read_thermals(self.metrics.contexts.Thermal)
         self.vendor.get_bmc().read_fans(self.metrics.contexts.Fans)
         self.vendor.get_bmc().read_power_consumption(self.metrics.contexts.PowerConsumption)
+        self.vendor.get_bmc().read_oob_power_consumption(self.metrics.contexts.PowerConsumption)
         self.vendor.get_bmc().read_power_supplies(self.metrics.contexts.PowerSupplies)
 
     def __monitor_pdus(self):

--- a/hwbench/environment/test_intel.py
+++ b/hwbench/environment/test_intel.py
@@ -1,0 +1,150 @@
+import pathlib
+
+from hwbench.bench.monitoring_structs import (
+    MonitorMetric,
+    Power,
+    PowerCategories,
+    Temperature,
+)
+
+from .test_vendors import PATCH_TYPES, TestVendors
+from .vendors.intel.intel_vendor import Intel
+
+path = pathlib.Path("")
+
+
+class TestIntel(TestVendors):
+    """Test Intel systems using Intel vendor with BMC/Redfish support"""
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            Intel("", None, "hwbench/tests/mocked_monitoring.cfg"),
+            *args,
+            **kwargs
+        )
+        self.path = "tests/vendors/Intel/"
+
+    def setUp(self):
+        # setUp is called by pytest to install patches
+        # Prepare the vendor specifics for Intel systems
+        self.install_patch(
+            "hwbench.environment.vendors.intel.intel_vendor.Intel.detect",
+            PATCH_TYPES.RETURN_VALUE,
+            True,
+        )
+        self.install_patch(
+            "hwbench.environment.vendors.bmc.BMC.run",
+            PATCH_TYPES.RETURN_VALUE,
+            True,
+        )
+        self.install_patch(
+            "hwbench.environment.vendors.intel.intel_bmc.IntelBMC.detect",
+            PATCH_TYPES.RETURN_VALUE,
+            None,
+        )
+        # Mock _get_chassis to return Avenue City chassis
+        self.install_patch(
+            "hwbench.environment.vendors.intel.intel_bmc.IntelBMC._get_chassis",
+            PATCH_TYPES.RETURN_VALUE,
+            ["/redfish/v1/Chassis/AVC_Baseboard"],
+        )
+        # Mock get_redfish_url to return chassis with Sensors collection
+        def mock_get_redfish_url(url):
+            if url == "/redfish/v1/Chassis/AVC_Baseboard":
+                return {
+                    "@odata.id": "/redfish/v1/Chassis/AVC_Baseboard",
+                    "Id": "AVC_Baseboard",
+                    "Name": "AVC Baseboard",
+                    "Sensors": {
+                        "@odata.id": "/redfish/v1/Chassis/AVC_Baseboard/Sensors"
+                    }
+                }
+            elif url == "/redfish/v1/Chassis/AVC_Baseboard/Sensors":
+                # Return the thermal data from the test file
+                return self.sample(self.path + "thermal")
+            return None
+        
+        self.install_patch(
+            "hwbench.environment.vendors.intel.intel_bmc.IntelBMC.get_redfish_url",
+            PATCH_TYPES.SIDE_EFFECT,
+            mock_get_redfish_url,
+        )
+        self.install_patch(
+            "hwbench.environment.vendors.intel.intel_bmc.IntelBMC.get_thermal",
+            PATCH_TYPES.RETURN_VALUE,
+            self.sample(self.path + "thermal"),
+        )
+        self.install_patch(
+            "hwbench.environment.vendors.intel.intel_bmc.IntelBMC.get_power",
+            PATCH_TYPES.RETURN_VALUE,
+            self.sample(self.path + "power"),
+        )
+        # And finish by calling the parent setUp()
+        super().setUp()
+
+    def test_thermal(self):
+        """Test thermal sensor reading from Intel Avenue City BMC
+        
+        Tests that the following sensors are properly categorized:
+        - Inlet/Outlet temperatures (airflow monitoring)
+        - CPU die temperatures (per-CPU thermal monitoring)
+        - Memory temperatures (DIMM thermal monitoring)
+        """
+        expected_output = self.generic_thermal_output()
+        expected_output["Intake"] = {
+            "Inlet": Temperature("Inlet", 25)
+        }
+        expected_output["Exhaust"] = {
+            "Outlet": Temperature("Outlet", 35)
+        }
+        expected_output["CPU"] = {
+            "CPU0 Die": Temperature("CPU0 Die", 45),
+            "CPU1 Die": Temperature("CPU1 Die", 43),
+        }
+        expected_output["Memory"] = {
+            "CPU0 DIMM": Temperature("CPU0 DIMM", 38),
+            "CPU1 DIMM": Temperature("CPU1 DIMM", 37),
+            "DIMM A0": Temperature("DIMM A0", 39),
+            "DIMM B0": Temperature("DIMM B0", 38),
+        }
+        super().generic_thermal_test(expected_output)
+
+    def test_fan(self):
+        """Test fan sensor reading from Intel BMC"""
+        expected_output = self.generic_fan_output()
+        expected_output.Fan = {
+            "Fan1": MonitorMetric("Fan1", "RPM", 5000),
+            "Fan2": MonitorMetric("Fan2", "RPM", 5200),
+        }
+        super().generic_fan_test(expected_output)
+
+    def test_power_consumption(self):
+        """Test power consumption reading from Intel BMC"""
+        expected_output = self.generic_power_output()
+        expected_output.BMC = {
+            "Server": Power("Server", 375.0),
+            "System Power Control": Power("System Power Control", 376.0),
+        }
+        super().generic_power_consumption_test(expected_output)
+
+    def test_oob_power_consumption(self):
+        """Test OOB (out-of-band) power consumption reading from Intel BMC"""
+        expected_output = self.generic_oob_power_output()
+        expected_output.BMC = {
+            "Processor0 Power Control": Power("Processor0 Power Control", 81.6),
+            "Processor1 Power Control": Power("Processor1 Power Control", 81.7),
+            "Processors Power Control": Power("Processors Power Control", 163.4),
+            "Memory0 Power Control": Power("Memory0 Power Control", 3.45),
+            "Memory1 Power Control": Power("Memory1 Power Control", 3.32),
+            "Memories Power Control": Power("Memories Power Control", 6.77),
+        }
+        super().generic_oob_power_consumption_test(expected_output)
+
+    def test_power_supplies(self):
+        """Test power supply reading from Intel BMC"""
+        expected_output = self.generic_power_supplies_output()
+        expected_output.BMC = {
+            "PSU1": Power("PSU1", 187.5),
+            "PSU2": Power("PSU2", 187.5),
+        }
+        super().generic_power_supplies_test(expected_output)

--- a/hwbench/environment/test_vendors.py
+++ b/hwbench/environment/test_vendors.py
@@ -117,6 +117,13 @@ class TestVendors(unittest.TestCase):
     def generic_power_output(self):
         return PowerConsumptionContext()
 
+    def generic_oob_power_output(self):
+        """Return a generic OOB power consumption context for testing"""
+        return PowerConsumptionContext()
+
+    def generic_power_supplies_output(self):
+        return PowerSuppliesContext()
+
     def generic_test(self, expected_output, func):
         expected_output_dict = dict(iterate_dataclass(expected_output))
         for pc, context in iterate_dataclass(func):
@@ -143,6 +150,12 @@ class TestVendors(unittest.TestCase):
     def generic_power_consumption_test(self, expected_output):
         return self.generic_test(
             expected_output, self.get_vendor().get_bmc().read_power_consumption(PowerConsumptionContext())
+        )
+
+    def generic_oob_power_consumption_test(self, expected_output):
+        """Test OOB power consumption reading from BMC"""
+        return self.generic_test(
+            expected_output, self.get_vendor().get_bmc().read_oob_power_consumption(PowerConsumptionContext())
         )
 
     def generic_power_supplies_test(self, expected_output):

--- a/hwbench/environment/tests/vendors/Intel/power
+++ b/hwbench/environment/tests/vendors/Intel/power
@@ -1,0 +1,46 @@
+{
+  "PowerControl": [
+    {
+      "Name": "Server",
+      "PowerConsumedWatts": 375.0
+    },
+    {
+      "Name": "System Power Control",
+      "PowerConsumedWatts": 376.0
+    },
+    {
+      "Name": "Processor0 Power Control",
+      "PowerConsumedWatts": 81.6
+    },
+    {
+      "Name": "Processor1 Power Control",
+      "PowerConsumedWatts": 81.7
+    },
+    {
+      "Name": "Processors Power Control",
+      "PowerConsumedWatts": 163.4
+    },
+    {
+      "Name": "Memory0 Power Control",
+      "PowerConsumedWatts": 3.45
+    },
+    {
+      "Name": "Memory1 Power Control",
+      "PowerConsumedWatts": 3.32
+    },
+    {
+      "Name": "Memories Power Control",
+      "PowerConsumedWatts": 6.77
+    }
+  ],
+  "PowerSupplies": [
+    {
+      "Name": "PSU1",
+      "PowerInputWatts": 187.5
+    },
+    {
+      "Name": "PSU2",
+      "PowerInputWatts": 187.5
+    }
+  ]
+}

--- a/hwbench/environment/tests/vendors/Intel/thermal
+++ b/hwbench/environment/tests/vendors/Intel/thermal
@@ -1,0 +1,64 @@
+{
+  "Sensors": [
+    {
+      "Name": "Inlet Temp",
+      "Reading": 25,
+      "ReadingType": "Temperature",
+      "ReadingUnits": "Celsius"
+    },
+    {
+      "Name": "Outlet Temp",
+      "Reading": 35,
+      "ReadingType": "Temperature",
+      "ReadingUnits": "Celsius"
+    },
+    {
+      "Name": "CPU0 Die Temp",
+      "Reading": 45,
+      "ReadingType": "Temperature",
+      "ReadingUnits": "Celsius"
+    },
+    {
+      "Name": "CPU1 Die Temp",
+      "Reading": 43,
+      "ReadingType": "Temperature",
+      "ReadingUnits": "Celsius"
+    },
+    {
+      "Name": "CPU0 DIMM Temp",
+      "Reading": 38,
+      "ReadingType": "Temperature",
+      "ReadingUnits": "Celsius"
+    },
+    {
+      "Name": "CPU1 DIMM Temp",
+      "Reading": 37,
+      "ReadingType": "Temperature",
+      "ReadingUnits": "Celsius"
+    },
+    {
+      "Name": "DIMM A0 Temp",
+      "Reading": 39,
+      "ReadingType": "Temperature",
+      "ReadingUnits": "Celsius"
+    },
+    {
+      "Name": "DIMM B0 Temp",
+      "Reading": 38,
+      "ReadingType": "Temperature",
+      "ReadingUnits": "Celsius"
+    },
+    {
+      "Name": "Fan1",
+      "Reading": 5000,
+      "ReadingType": "Rotational",
+      "ReadingUnits": "RPM"
+    },
+    {
+      "Name": "Fan2",
+      "Reading": 5200,
+      "ReadingType": "Rotational",
+      "ReadingUnits": "RPM"
+    }
+  ]
+}

--- a/hwbench/environment/vendors/bmc.py
+++ b/hwbench/environment/vendors/bmc.py
@@ -180,6 +180,17 @@ class BMC(MonitoringDevice, External):
             return next(iter(th.values()))  # return only element
         return {}  # return nothing if there are more than 1 elements
 
+    def read_oob_power_consumption(self, power_consumption: PowerConsumptionContext) -> PowerConsumptionContext:
+        """Return all power consumptions from BMC (OOB)"""
+        for power_ctrl in self.get_power().get("PowerControl", []):
+            name = power_ctrl.get("Name", "")
+            cpu_power = power_ctrl.get("PowerConsumedWatts", None)
+            if cpu_power:
+                if name not in power_consumption.BMC:
+                    power_consumption.BMC[name] = Power(name)
+                power_consumption.BMC[name].add(cpu_power)
+        return power_consumption
+
     def read_power_consumption(self, power_consumption: PowerConsumptionContext) -> PowerConsumptionContext:
         """Return power consumption from server"""
         # Generic for now, could be overriden by vendors

--- a/hwbench/environment/vendors/detect.py
+++ b/hwbench/environment/vendors/detect.py
@@ -6,12 +6,14 @@ from .amd.amd import Amd
 from .dell.dell import Dell
 from .generic import GenericVendor
 from .hpe.hpe import Hpe
+from .intel.intel_vendor import Intel
 from .vendor import Vendor
 
 VENDOR_LIST = [
     Dell,
     Hpe,
     Amd,
+    Intel,
     # This one always detects the hardware and should be kept at the end
     GenericVendor,
 ]

--- a/hwbench/environment/vendors/intel/__init__.py
+++ b/hwbench/environment/vendors/intel/__init__.py
@@ -1,0 +1,5 @@
+"""Intel vendor package"""
+from .intel_bmc import IntelBMC
+from .intel_vendor import Intel
+
+__all__ = ["Intel", "IntelBMC"]

--- a/hwbench/environment/vendors/intel/intel_bmc.py
+++ b/hwbench/environment/vendors/intel/intel_bmc.py
@@ -1,0 +1,429 @@
+"""Intel vendor-specific implementation"""
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+from hwbench.bench.monitoring_structs import (
+    FansContext,
+    MonitorMetric,
+    Power,
+    PowerCategories,
+    PowerConsumptionContext,
+    Temperature,
+    ThermalContext,
+)
+
+from ..bmc import BMC
+
+
+class IntelBMC(BMC):
+    """Intel-specific BMC implementation for Avenue City and other Intel platforms"""
+
+    def __init__(self, out_dir: pathlib.Path, vendor):
+        super().__init__(out_dir, vendor)
+        self.is_avenue_city = None  # None = not checked yet, True/False after check
+
+    def _check_avenue_city(self):
+        """Check if this is Avenue City platform (lazy detection)"""
+        if self.is_avenue_city is not None:
+            return self.is_avenue_city
+        
+        try:
+            chassis_list = self._get_chassis()
+            for chassis_url in chassis_list:
+                if "AVC_Baseboard" in chassis_url:
+                    self.is_avenue_city = True
+                    print("Detected Intel Avenue City platform")
+                    return True
+        except Exception as e:
+            print(f"WARNING: Could not check for Avenue City platform: {e}")
+        
+        self.is_avenue_city = False
+        return False
+
+    def detect(self):
+        """Detect Intel BMC and platform type"""
+        super().detect()
+        # Trigger Avenue City detection
+        self._check_avenue_city()
+
+    def _get_chassis_thermals(self) -> dict[str, str]:
+        """Override to handle Intel Avenue City's ThermalSubsystem endpoint"""
+        if not self._check_avenue_city():
+            # Use standard thermal endpoint for non-Avenue City Intel platforms
+            return super()._get_chassis_thermals()
+        
+        # For Avenue City, use ThermalSubsystem endpoint
+        thermals = {}
+        for chassis_url in self._get_chassis():
+            chassis = self.get_redfish_url(chassis_url)
+            chassis_name = chassis_url.rstrip("/").split("/")[-1]
+            
+            # Try ThermalSubsystem endpoint first (Avenue City)
+            thermal_subsystem = chassis.get("ThermalSubsystem")
+            if thermal_subsystem and "@odata.id" in thermal_subsystem:
+                thermal_subsystem_url = thermal_subsystem["@odata.id"]
+                
+                # Get the ThermalSubsystem object to check for Sensors collection
+                thermal_subsystem_data = self.get_redfish_url(thermal_subsystem_url)
+                
+                # Look for temperature-related endpoints
+                sensor_url = None
+                
+                # Check for Sensors collection in ThermalSubsystem
+                if thermal_subsystem_data and "Sensors" in thermal_subsystem_data:
+                    sensors_ref = thermal_subsystem_data["Sensors"]
+                    if isinstance(sensors_ref, dict) and "@odata.id" in sensors_ref:
+                        sensor_url = sensors_ref["@odata.id"]
+                
+                # Check for ThermalMetrics (common in Redfish 2020+)
+                if not sensor_url and thermal_subsystem_data and "ThermalMetrics" in thermal_subsystem_data:
+                    metrics_ref = thermal_subsystem_data["ThermalMetrics"]
+                    if isinstance(metrics_ref, dict) and "@odata.id" in metrics_ref:
+                        sensor_url = metrics_ref["@odata.id"]
+                
+                # Check for TemperatureSensors (some implementations)
+                if not sensor_url and thermal_subsystem_data and "TemperatureSensors" in thermal_subsystem_data:
+                    temp_ref = thermal_subsystem_data["TemperatureSensors"]
+                    if isinstance(temp_ref, dict) and "@odata.id" in temp_ref:
+                        sensor_url = temp_ref["@odata.id"]
+                
+                if sensor_url:
+                    thermals[chassis_name] = sensor_url
+                else:
+                    # No specific sensors endpoint found in ThermalSubsystem
+                    # Check if ThermalSubsystem itself has embedded sensor arrays (Sensors or Temperatures, not Fans)
+                    if thermal_subsystem_data and any(k in thermal_subsystem_data for k in ['Sensors', 'Temperatures']):
+                        thermals[chassis_name] = thermal_subsystem_url
+            
+            # Check for Sensors collection directly on Chassis (Avenue City pattern)
+            if chassis_name not in thermals and "Sensors" in chassis:
+                sensors_ref = chassis["Sensors"]
+                if isinstance(sensors_ref, dict) and "@odata.id" in sensors_ref:
+                    sensor_url = sensors_ref["@odata.id"]
+                    thermals[chassis_name] = sensor_url
+            
+            # Fallback to standard Thermal endpoint if nothing found yet
+            if chassis_name not in thermals:
+                thermal_url = self._chassis_item_url(chassis, "Thermal")
+                if thermal_url:
+                    thermals[chassis_name] = thermal_url
+        
+        return thermals
+
+    def read_thermals(self, thermals: ThermalContext) -> ThermalContext:
+        """Override to handle Intel Avenue City's thermal data structure"""
+        if not self._check_avenue_city():
+            # Use standard thermal reading for non-Avenue City platforms
+            return super().read_thermals(thermals)
+        
+        # For Avenue City, read from ThermalSubsystem
+        th = self._get_thermals()
+        
+        if not th:
+            return thermals
+        
+        for chassis, thermal_data in th.items():
+            prefix = ""
+            if len(th) > 1:
+                prefix = chassis + "-"
+            
+            # Check if this is a Sensors collection (has Members array)
+            if "Members" in thermal_data:
+                members = thermal_data.get("Members", [])
+                # Filter to only temperature sensors by URL pattern
+                temp_members = [m for m in members if isinstance(m, dict) and 
+                               "@odata.id" in m and "temperature_" in m["@odata.id"].lower()]
+                
+                # Only print debug during first fetch (when we have many members to process)
+                if len(members) > 0 and prefix == "":
+                    print(f"DEBUG: Found {len(members)} sensor members, filtered to {len(temp_members)} temperature sensors")
+                
+                # This is a collection of sensors, each Member is a reference
+                for member_ref in temp_members:
+                    sensor_url = member_ref["@odata.id"]
+                    sensor_data = self.get_redfish_url(sensor_url)
+                    if sensor_data:
+                        self._process_avenue_city_sensor(sensor_data, thermals, prefix)
+            
+            # Check if this is ThermalSubsystem format (has Sensors array)
+            elif "Sensors" in thermal_data:
+                sensors = thermal_data.get("Sensors", [])
+                # Avenue City format: ThermalSubsystem with Sensors
+                for sensor in sensors:
+                    # Process sensor directly (they're complete objects, not references)
+                    self._process_avenue_city_sensor(sensor, thermals, prefix)
+            
+            # Also check for standard Temperatures array (fallback)
+            elif "Temperatures" in thermal_data:
+                temps = thermal_data.get("Temperatures", [])
+                for t in temps:
+                    if t.get("ReadingCelsius") is None or t["ReadingCelsius"] <= 0:
+                        continue
+                    name = prefix + t["Name"].split("Temp")[0].strip()
+                    
+                    self.add_monitoring_value(
+                        thermals,
+                        t.get("PhysicalContext", "UnknownPhysicalContext"),
+                        Temperature(name),
+                        t["Name"],
+                        t["ReadingCelsius"],
+                    )
+            # Unknown format - silently skip (don't spam console during monitoring loop)
+        
+        return thermals
+
+    def _process_avenue_city_sensor(self, sensor_data: dict, thermals: ThermalContext, prefix: str):
+        """Process Avenue City sensor data
+        
+        Categorizes sensors into:
+        - Intake: Inlet temperature sensors
+        - Exhaust: Outlet/exhaust temperature sensors  
+        - CPU: CPU die temperature sensors
+        - Memory: DIMM/Memory temperature sensors
+        
+        By default, only critical sensors are reported to reduce noise in results.json.
+        Uncomment categories below to enable additional sensors.
+        """
+        reading = sensor_data.get("Reading")
+        name = sensor_data.get("Name", "Unknown")
+        reading_type = sensor_data.get("ReadingType", "")
+        
+        # Skip invalid readings or non-temperature sensors
+        if reading is None or reading <= 0:
+            return
+        
+        # Only process temperature readings
+        if reading_type and reading_type != "Temperature":
+            return
+        
+        # Determine physical context from sensor name
+        physical_context = "UnknownPhysicalContext"
+        name_upper = name.upper()
+        
+        # === ENABLED SENSORS (uncomment to add more) ===
+        
+        # Intake/Inlet temperatures (air entering chassis)
+        if "INLET" in name_upper or "INTAKE" in name_upper:
+            physical_context = "Intake"
+            
+        # CPU die temperatures (processor cores)
+        elif ("CPU" in name_upper and "DIE" in name_upper) or "PROCESSOR" in name_upper:
+            physical_context = "CPU"
+            
+        # Memory Bank temperatures (aggregate for left/right DIMM banks)
+        # Matches: "Left DIMM Bank", "Right DIMM Bank", "temperature_Left_DIMM_Bank_Temp"
+        # but NOT: "CPU0 DIMM", "DIMM A0", etc.
+        elif "BANK" in name_upper and ("DIMM" in name_upper or "MEMORY" in name_upper or "MEM" in name_upper):
+            physical_context = "Memory"
+            
+        # === DISABLED SENSORS (uncomment to enable) ===
+        
+        # CPU-level DIMM aggregates (e.g., "CPU0 DIMM Temp", "CPU1 DIMM Temp")
+        # elif "CPU" in name_upper and "DIMM" in name_upper and "BANK" not in name_upper:
+        #     physical_context = "Memory"
+        
+        # Individual DIMM temperatures (e.g., "DIMM A0", "DIMM B0")
+        # elif "DIMM" in name_upper and "CPU" not in name_upper and "BANK" not in name_upper:
+        #     physical_context = "Memory"
+        
+        # General memory sensors without Bank/DIMM specification
+        # elif ("MEMORY" in name_upper or "MEM" in name_upper) and "CPU" not in name_upper and "DIMM" not in name_upper:
+        #     physical_context = "Memory"
+        
+        # === DISABLED SENSORS (uncomment to enable) ===
+        
+        # Exhaust/Outlet temperatures (air leaving chassis)
+        # elif "OUTLET" in name_upper or "EXHAUST" in name_upper:
+        #     physical_context = "Exhaust"
+        
+        # Motherboard/baseboard temperatures
+        # elif "BOARD" in name_upper or "BASEBOARD" in name_upper:
+        #     physical_context = "SystemBoard"
+        
+        # Voltage regulator temperatures
+        # elif "VR" in name_upper or "VOLTAGE" in name_upper:
+        #     physical_context = "VoltageRegulator"
+        
+        # If sensor doesn't match any enabled category, skip it
+        else:
+            return
+        
+        # Clean up sensor name - remove temperature-related suffixes only at the end
+        clean_name = name
+        for suffix in [" Temperature", " Temp"]:
+            if clean_name.endswith(suffix):
+                clean_name = clean_name[:-len(suffix)]
+                break
+        clean_name = prefix + clean_name.strip()
+        
+        self.add_monitoring_value(
+            thermals,
+            physical_context,
+            Temperature(clean_name),
+            name,
+            reading,
+        )
+
+    def read_fans(self, fans: FansContext) -> FansContext:
+        """Override to handle Intel Avenue City's fan data"""
+        if not self._check_avenue_city():
+            return super().read_fans(fans)
+        
+        # For Avenue City, get chassis thermal endpoints
+        chassis_thermals = self._get_chassis_thermals()
+        
+        for chassis_name, sensor_url in chassis_thermals.items():
+            # Fetch the Sensors collection
+            sensor_collection = self.get_redfish_url(sensor_url)
+            
+            # Check if this is a Members collection
+            if "Members" in sensor_collection:
+                members = sensor_collection.get("Members", [])
+                
+                # Filter to only fan sensors by URL pattern
+                fan_members = [m for m in members if isinstance(m, dict) and 
+                              "@odata.id" in m and "fan" in m["@odata.id"].lower()]
+                
+                # Fetch each fan sensor
+                for member_ref in fan_members:
+                    fan_url = member_ref["@odata.id"]
+                    sensor_data = self.get_redfish_url(fan_url)
+                    
+                    # Verify this is a fan/rotational sensor
+                    reading_type = sensor_data.get("ReadingType", "")
+                    if reading_type and reading_type.lower() not in ["rotational"]:
+                        continue
+                    
+                    name = sensor_data.get("Name", "Unknown Fan")
+                    reading = sensor_data.get("Reading")
+                    unit = sensor_data.get("ReadingUnits", "RPM")
+                    
+                    if reading is not None and reading > 0:
+                        if name not in fans.Fan:
+                            fans.Fan[name] = MonitorMetric(name, unit)
+                        fans.Fan[name].add(reading)
+            
+            # Check for embedded Fans array (fallback)
+            elif "Fans" in sensor_collection:
+                for f in sensor_collection.get("Fans", []):
+                    name = f.get("Name", "Unknown Fan")
+                    reading = f.get("Reading")
+                    unit = f.get("ReadingUnits", "RPM")
+                    
+                    if reading is not None and reading > 0:
+                        if name not in fans.Fan:
+                            fans.Fan[name] = MonitorMetric(name, unit)
+                        fans.Fan[name].add(reading)
+        
+        return fans
+
+    def get_power(self):
+        """Override to handle Avenue City's multiple chassis
+        
+        Avenue City has multiple chassis (AVC_Baseboard, AVC_2UDIMM_Baseboard).
+        We want the main baseboard (AVC_Baseboard) for power metrics.
+        """
+        if not self._check_avenue_city():
+            return super().get_power()
+        
+        # Get power from all chassis
+        powers = self._get_powers()
+        
+        # For Avenue City, prefer AVC_Baseboard which has the power data
+        if "AVC_Baseboard" in powers:
+            return powers["AVC_Baseboard"]
+        
+        # Fallback to first available
+        if powers:
+            return next(iter(powers.values()))
+        
+        return {}
+
+    def read_oob_power_consumption(self, power_consumption: PowerConsumptionContext) -> PowerConsumptionContext:
+        """Override to prevent duplicate power entries.
+        
+        Intel Avenue City provides detailed power breakdown which is handled
+        in read_power_consumption() with cleaned names (Server, CPU, Memory).
+        We skip the parent's read_oob_power_consumption() to avoid duplicates
+        with raw names (System Power Control, Processors Power Control, etc.).
+        """
+        # Don't call parent - read_power_consumption handles it with cleaned names
+        return power_consumption
+
+    def read_power_consumption(self, power_consumption: PowerConsumptionContext) -> PowerConsumptionContext:
+        """Override to handle Intel Avenue City's power data structure
+        
+        Avenue City provides detailed power breakdown in PowerControl array:
+        - System Power Control: Total server power
+        - Processors Power Control: Total CPU power
+        - Processor0 Power Control: Individual CPU power
+        - Memories Power Control: Total memory power
+        - Memory0 Power Control: Individual memory power
+        """
+        if not self._check_avenue_city():
+            return super().read_power_consumption(power_consumption)
+        
+        power_data = self.get_power()
+        if not power_data:
+            return power_consumption
+            
+        power_controls = power_data.get("PowerControl", [])
+        
+        for pc in power_controls:
+            name = pc.get("Name", "")
+            power_watts = pc.get("PowerConsumedWatts")
+            
+            if power_watts is None:
+                continue
+            
+            # System/Server total power
+            if "System" in name or name == "Server":
+                if str(PowerCategories.SERVER) not in power_consumption.BMC:
+                    power_consumption.BMC[str(PowerCategories.SERVER)] = Power("Server")
+                power_consumption.BMC[str(PowerCategories.SERVER)].add(power_watts)
+            
+            # CPU power (aggregate or individual)
+            elif "Processor" in name:
+                # Use aggregate "Processors" if available, otherwise individual
+                # Check if this is the aggregate (plural) vs individual (Processor0, Processor1, etc.)
+                if "Processors" in name:
+                    # This is aggregate - check it's not also an individual like "Processor01"
+                    # Extract what comes after "Processor" to see if it's just "s" or a number
+                    after_processor = name.split("Processor")[1] if len(name.split("Processor")) > 1 else ""
+                    if after_processor.startswith("s"):  # "Processors Power Control"
+                        if "CPU" not in power_consumption.CPU:
+                            power_consumption.CPU["CPU"] = Power("CPU")
+                        power_consumption.CPU["CPU"].add(power_watts)
+                else:
+                    # Individual processor: Processor0, Processor1, Processor2, etc.
+                    # Extract the processor name (e.g., "Processor0" from "Processor0 Power Control")
+                    cpu_name = name.split()[0]
+                    if cpu_name.startswith("Processor") and any(c.isdigit() for c in cpu_name):
+                        if cpu_name not in power_consumption.CPU:
+                            power_consumption.CPU[cpu_name] = Power(cpu_name)
+                        power_consumption.CPU[cpu_name].add(power_watts)
+            
+            # Memory power (aggregate or individual)
+            elif "Memor" in name:  # Matches both "Memory" and "Memories"
+                # Use aggregate "Memories" if available, otherwise individual
+                # Check if this is the aggregate (plural) vs individual (Memory0, Memory1, etc.)
+                if "Memories" in name:
+                    # This is aggregate - check it's not also an individual like "Memory01"
+                    # Extract what comes after "Memor" to see if it's "ies" or a number
+                    after_memor = name.split("Memor")[1] if len(name.split("Memor")) > 1 else ""
+                    if after_memor.startswith("ies"):  # "Memories Power Control"
+                        if "Memory" not in power_consumption.BMC:
+                            power_consumption.BMC["Memory"] = Power("Memory")
+                        power_consumption.BMC["Memory"].add(power_watts)
+                else:
+                    # Individual memory: Memory0, Memory1, Memory2, etc.
+                    # Extract the memory name (e.g., "Memory0" from "Memory0 Power Control")
+                    mem_name = name.split()[0]
+                    if mem_name.startswith("Memory") and any(c.isdigit() for c in mem_name):
+                        if mem_name not in power_consumption.BMC:
+                            power_consumption.BMC[mem_name] = Power(mem_name)
+                        power_consumption.BMC[mem_name].add(power_watts)
+        
+        return power_consumption

--- a/hwbench/environment/vendors/intel/intel_vendor.py
+++ b/hwbench/environment/vendors/intel/intel_vendor.py
@@ -1,0 +1,64 @@
+"""Intel vendor implementation"""
+from __future__ import annotations
+
+import pathlib
+
+from ..vendor import Vendor
+from .intel_bmc import IntelBMC
+
+
+class Intel(Vendor):
+    """Intel vendor implementation"""
+
+    def __init__(self, out_dir: pathlib.Path, dmi, monitoring_config_filename: str):
+        super().__init__(out_dir, dmi, monitoring_config_filename)
+
+    def detect(self) -> bool:
+        """Detect if this is an Intel system"""
+        if not self.dmi:
+            return False
+        
+        # Check if manufacturer is Intel
+        manufacturer = self.dmi.info("sys_vendor")
+        product = self.dmi.info("product_name")
+        
+        if not manufacturer:
+            return False
+        
+        manufacturer_lower = manufacturer.lower()
+        product_lower = product.lower() if product else ""
+        
+        # Intel systems typically have "Intel" or "Intel Corporation" as manufacturer
+        # or specific Intel product names like "Avenue City"
+        is_intel = (
+            "intel" in manufacturer_lower or
+            "Intel Corporation" in manufacturer_lower or
+            "AvenueCity" in product_lower or
+            "intel server" in product_lower
+        )
+        
+        return is_intel
+
+    def prepare(self):
+        """Prepare Intel vendor"""
+        if self.get_monitoring_config_filename():
+            # Replace generic BMC with Intel-specific BMC before calling super().prepare()
+            self.bmc = IntelBMC(self.out_dir, self)
+            self.bmc.run()
+        super().prepare()
+
+    def save_bios_config(self):
+        """Save BIOS configuration"""
+        print("Saving Intel BIOS configuration via Redfish")
+        # TODO: Implement Intel-specific BIOS config dump via Redfish
+        self.out_dir.joinpath("intel-bios-config").write_text("")
+
+    def save_bmc_config(self):
+        """Save BMC configuration"""
+        print("Saving Intel BMC configuration via Redfish")
+        # TODO: Implement Intel-specific BMC config dump via Redfish
+        self.out_dir.joinpath("intel-bmc-config").write_text("")
+
+    def name(self) -> str:
+        """Return vendor name"""
+        return "Intel"


### PR DESCRIPTION
This change allows to monitor all Power Control elements in the BMC.
It monitors each CPU power usage and all CPUs power combined, each Memory dimm power usage and all dimms combined.

It also take the whole Server power, so it could replace read_power_consumption function.

Currently the report looks like this:
{
  "Server": {},
  "System Power Control": {},
  "Processor0 Power Control": {},
  "Processor1 Power Control": {},
  "Processors Power Control": {},
  "Memory0 Power Control": {},
  "Memory1 Power Control": {},
  "Memories Power Control": {}
}

Server and System Power Control - give the same values
On my system there where 2 processors and 2 memory dimms that is why those are listed here.