### PR TITLE
config: Adding 'numa-simple' helper

### DIFF
--- a/hwbench/bench/test_numa.py
+++ b/hwbench/bench/test_numa.py
@@ -35,6 +35,25 @@ class TestNuma(tbc.TestCommon):
         ]:
             self.should_be_fatal(self.get_jobs_config().get_hosting_cpu_cores, test_name)
 
+    def test_numa_simple(self):
+        """Check the numa-simple helper expands to one cpu group per NUMA node."""
+        cpu = self.hw.get_cpu()
+        assert cpu.get_numa_domains_count() == 8
+        # One group per NUMA node, in domain order, cores sorted.
+        all_numa_nodes = [
+            sorted(cpu.get_logical_cores_in_numa_domain(domain)) for domain in range(cpu.get_numa_domains_count())
+        ]
+        # Sanity check against the known topology of this mocked AMD system
+        assert all_numa_nodes[0] == self.NUMA0
+        assert all_numa_nodes[1] == self.NUMA1
+        assert all_numa_nodes[7] == self.NUMA7
+
+        assert self.get_jobs_config().get_hosting_cpu_cores("numa_simple") == all_numa_nodes
+
+        # numa_simple benchmarks are scheduled after numa_nodes (5) and quadrants (4)
+        for index, numa_node in enumerate(all_numa_nodes):
+            assert self.get_bench_parameters(9 + index).get_pinned_cpu() == numa_node
+
     def test_numa(self):
         """Check numa syntax"""
         assert self.hw.logical_core_count() == 128

--- a/hwbench/config/config.py
+++ b/hwbench/config/config.py
@@ -163,13 +163,14 @@ class Config:
             hcc = hcc.replace("all", f"0-{self.hardware.get_cpu().get_logical_cores_count() - 1}")
 
         # Let's replace helpers if any
-        helpers = re.findall("simple", hcc)
-        if helpers:
-            for helper in helpers:
-                helper_module = importlib.import_module(  # noqa: F841
-                    ".config_helpers", package="hwbench.config"
-                )
-                hcc = hcc.replace(helper, eval(f"helper_module.{helper}")(self.hardware), 1)
+        # Helpers are listed longest-first so a shorter name (simple) cannot
+        # partially match a longer one (numa-simple). The keyword's dashes are
+        # mapped to underscores to match the function name in config_helpers.
+        helper_module = importlib.import_module(".config_helpers", package="hwbench.config")
+        for helper in ["numa-simple", "simple"]:
+            while helper in hcc:
+                helper_function = getattr(helper_module, helper.replace("-", "_"))
+                hcc = hcc.replace(helper, helper_function(self.hardware), 1)
 
         # If the hcc has some numa domains, lets expand them.
         # Let's search if there is any numa keyword

--- a/hwbench/config/config.txt
+++ b/hwbench/config/config.txt
@@ -55,6 +55,8 @@ hosting_cpu_cores:
                 none       : all cores are selected but no pinning is performed (default)
                 list       : items in hosting_cpu_cores list are considered separately
                 simple     : 1, 2, 3, 4, 8, 16 then +16 up to the physical cores count
+                numa-simple: one cpu group per available NUMA node of the system
+                             (equivalent to listing numa0 numa1 ... numaN as groups)
 
 
 hosting_cpu_cores_scaling:

--- a/hwbench/config/config_helpers.py
+++ b/hwbench/config/config_helpers.py
@@ -34,3 +34,13 @@ def simple(hardware: env_hw.BaseHardware) -> str:
                 cpu_list += hardware.get_cpu().get_peer_siblings(cpu)
             global_cpu_list += ",".join(str(e) for e in sorted(cpu_list)) + " "
     return global_cpu_list.strip()
+
+
+def numa_simple(hardware: env_hw.BaseHardware) -> str:
+    """Return one cpu group per available NUMA node on the system."""
+    cpu = hardware.get_cpu()
+    groups = []
+    for numa_domain in range(cpu.get_numa_domains_count()):
+        cores = cpu.get_logical_cores_in_numa_domain(numa_domain)
+        groups.append(",".join(str(core) for core in sorted(cores)))
+    return " ".join(groups)

--- a/hwbench/config/config_syntax.py
+++ b/hwbench/config/config_syntax.py
@@ -78,14 +78,16 @@ def validate_hosting_cpu_cores(config, section_name, value) -> str:
         if value.isnumeric():
             return ""
         else:
-            ressources = re.findall(r"(quadrant|numa|core)([0-9-,]+)", value.lower())
+            value = value.lower()
+            # Helpers are removed first (longest-first so 'simple' cannot
+            # partially match 'numa-simple') before parsing the resources,
+            # otherwise the numa resource regex would eat 'numa-' from 'numa-simple'.
+            for helper in ["numa-simple", "simple", "all"]:
+                value = value.replace(helper, "", 1)
+            ressources = re.findall(r"(quadrant|numa|core)([0-9-,]+)", value)
             if ressources:
                 for ressource in ressources:
-                    value = value.lower().replace(f"{ressource[0]}{ressource[1]}", "", 1)
-            for helper in ["all", "simple"]:
-                ressources = re.findall(rf"{helper}", value.lower())
-                if ressources:
-                    value = value.lower().replace(f"{helper}", "", 1)
+                    value = value.replace(f"{ressource[0]}{ressource[1]}", "", 1)
             range = config.parse_range(value)
             if range:
                 value = value.lower().replace(value, "", 1)

--- a/hwbench/config/numa.conf
+++ b/hwbench/config/numa.conf
@@ -11,3 +11,8 @@ hosting_cpu_cores=NUMA0 NUMA1 NUMA7 NUMA0-7 NUMA0,1
 engine=sleep
 stressor_range=auto
 hosting_cpu_cores=QUADRANT0 QUADRANT1 QUADRANT0-3 QUADRANT0,1
+
+[numa_simple]
+engine=sleep
+stressor_range=auto
+hosting_cpu_cores=numa-simple


### PR DESCRIPTION
This hosting cpu cores helper is implemented to expand to one cpu group per available NUMA node of the system.

The hosting_cpu_cores=numa-simple is replaced by the list of logical cores of every NUMA node, one group per node, reusing the existing NUMA detection code.

For an 8 NUMA nodes system, this 'numa-simple' helper is replaced by a serie of groups, one per node.
It's similar to "numa0 numa1 numa2 numa3 numa4 numa5 numa6 numa7".

Combined with the default hosting_cpu_cores_scaling=iterate, a sub job is executed for each NUMA node.