### PR TITLE
config: make numa-simple cumulative across NUMA nodes

### DIFF
--- a/hwbench/bench/test_numa.py
+++ b/hwbench/bench/test_numa.py
@@ -13,7 +13,7 @@ class TestNuma(tbc.TestCommon):
         self.NUMA1 = list(range(8, 16)) + list(range(72, 80))
         self.NUMA0_1 = sorted(self.NUMA0 + self.NUMA1)
         self.NUMA7 = list(range(56, 64)) + list(range(120, 128))
-        self.NUMA07 = list(range(0, self.hw.get_cpu().get_logical_cores_count()))
+        self.NUMA0_7 = list(range(0, self.hw.get_cpu().get_logical_cores_count()))
         self.load_benches("./hwbench/config/numa.conf")
         self.parse_jobs_config()
 
@@ -36,22 +36,25 @@ class TestNuma(tbc.TestCommon):
             self.should_be_fatal(self.get_jobs_config().get_hosting_cpu_cores, test_name)
 
     def test_numa_simple(self):
-        """Check the numa-simple helper expands to one cpu group per NUMA node."""
+        """Check the numa-simple helper accumulates NUMA nodes one at a time."""
         cpu = self.hw.get_cpu()
         assert cpu.get_numa_domains_count() == 8
-        # One group per NUMA node, in domain order, cores sorted.
-        all_numa_nodes = [
-            sorted(cpu.get_logical_cores_in_numa_domain(domain)) for domain in range(cpu.get_numa_domains_count())
-        ]
-        # Sanity check against the known topology of this mocked AMD system
-        assert all_numa_nodes[0] == self.NUMA0
-        assert all_numa_nodes[1] == self.NUMA1
-        assert all_numa_nodes[7] == self.NUMA7
+        # Cumulative groups: NUMA0, NUMA0-1, NUMA0-2, ... in domain order, cores sorted.
+        cumulative_numa_nodes = []
+        cores: list[int] = []
+        for domain in range(cpu.get_numa_domains_count()):
+            cores += cpu.get_logical_cores_in_numa_domain(domain)
+            cumulative_numa_nodes.append(sorted(cores))
 
-        assert self.get_jobs_config().get_hosting_cpu_cores("numa_simple") == all_numa_nodes
+        # Sanity check against the known topology of this mocked AMD system
+        assert cumulative_numa_nodes[0] == self.NUMA0
+        assert cumulative_numa_nodes[1] == self.NUMA0_1
+        assert cumulative_numa_nodes[7] == self.NUMA0_7
+
+        assert self.get_jobs_config().get_hosting_cpu_cores("numa_simple") == cumulative_numa_nodes
 
         # numa_simple benchmarks are scheduled after numa_nodes (5) and quadrants (4)
-        for index, numa_node in enumerate(all_numa_nodes):
+        for index, numa_node in enumerate(cumulative_numa_nodes):
             assert self.get_bench_parameters(9 + index).get_pinned_cpu() == numa_node
 
     def test_numa(self):
@@ -64,14 +67,14 @@ class TestNuma(tbc.TestCommon):
             self.NUMA0,
             self.NUMA1,
             self.NUMA7,
-            self.NUMA07,
+            self.NUMA0_7,
             self.NUMA0_1,
         ]
 
         assert self.get_bench_parameters(0).get_pinned_cpu() == self.NUMA0
         assert self.get_bench_parameters(1).get_pinned_cpu() == self.NUMA1
         assert self.get_bench_parameters(2).get_pinned_cpu() == self.NUMA7
-        assert self.get_bench_parameters(3).get_pinned_cpu() == self.NUMA07
+        assert self.get_bench_parameters(3).get_pinned_cpu() == self.NUMA0_7
         assert self.get_bench_parameters(4).get_pinned_cpu() == self.NUMA0_1
 
         # Testing broken syntax that must fail

--- a/hwbench/config/config_helpers.py
+++ b/hwbench/config/config_helpers.py
@@ -37,10 +37,11 @@ def simple(hardware: env_hw.BaseHardware) -> str:
 
 
 def numa_simple(hardware: env_hw.BaseHardware) -> str:
-    """Return one cpu group per available NUMA node on the system."""
+    """Return cumulative cpu groups, adding one more NUMA node at each step."""
     cpu = hardware.get_cpu()
     groups = []
+    cores: list[int] = []
     for numa_domain in range(cpu.get_numa_domains_count()):
-        cores = cpu.get_logical_cores_in_numa_domain(numa_domain)
+        cores += cpu.get_logical_cores_in_numa_domain(numa_domain)
         groups.append(",".join(str(core) for core in sorted(cores)))
     return " ".join(groups)


### PR DESCRIPTION
numa-simple previously produced one isolated cpu group per NUMA node (NUMA0, NUMA1, ...), which doesn't exercise cross-NUMA scaling. It now accumulates nodes progressively (NUMA0, NUMA0-1, NUMA0-2, ...) similar to the existing 'simple' cpu scaling helper.