### PR TITLE
hwgraph: improve rendering

### DIFF
--- a/graph/graph.py
+++ b/graph/graph.py
@@ -259,12 +259,14 @@ class Graph:
             if handles:
                 legends.append(self.ax.legend(bbox_to_anchor=(-0.05, 1), title="component [min; mean; stddev; max]\n"))
             if self.ax2:
-                # Upper right
+                # Anchor the legend by its left edge, just right of the 2nd y-axis
+                # (past its tick labels and title), so it grows outward instead of
+                # back over the axis regardless of how wide/long its labels get.
                 handles2, labels2 = self.ax2.get_legend_handles_labels()
                 if handles2:
                     legends.append(
                         self.ax2.legend(
-                            loc="upper right", bbox_to_anchor=(1.3, 1), title="component [min; mean; stddev; max]\n"
+                            loc="upper left", bbox_to_anchor=(1.05, 1), title="component [min; mean; stddev; max]\n"
                         )
                     )
 

--- a/graph/graph.py
+++ b/graph/graph.py
@@ -198,6 +198,10 @@ class Graph:
                 fontsize=14,
                 verticalalignment="top",
                 bbox=props,
+                # Use a proportional font here: with the cairo backend the width
+                # of monospace text is mismeasured, so its rounded box comes out
+                # too narrow and the (often long) filename spills past the frame.
+                fontfamily="sans-serif",
             )
 
     def get_ax(self):

--- a/graph/graph.py
+++ b/graph/graph.py
@@ -38,6 +38,7 @@ class Graph:
         filename,
         square=False,
         show_source_file=None,
+        title_note=None,
     ) -> None:
         self.ax2: Axes | None = None
         self.args = args
@@ -50,7 +51,7 @@ class Graph:
             self.fig.set_size_inches(args.width / self.dpi, args.height / self.dpi)
         self.set_labels(xlabel, ylabel)
         self.set_xticks_style()
-        self.set_title(title, show_source_file)
+        self.set_title(title, show_source_file, title_note)
         self.output_dir = output_dir
         output_dir.mkdir(parents=True, exist_ok=True)
         self.set_filename(filename)
@@ -156,9 +157,23 @@ class Graph:
         self.ax.grid(which="major", linewidth=1)
         self.ax.grid(which="minor", linewidth=0.2, linestyle="dashed")
 
-    def set_title(self, title, show_source_file=None):
+    def set_title(self, title, show_source_file=None, title_note=None):
         """Set the graph title"""
-        self.ax.set_title(title)
+        # When a note is present, push the main title up to leave room for the
+        # note, which is rendered just above the axes in bold dark red.
+        self.ax.set_title(title, pad=28 if title_note else None)
+        if title_note:
+            self.ax.text(
+                0.5,
+                1.0,
+                title_note,
+                transform=self.ax.transAxes,
+                horizontalalignment="center",
+                verticalalignment="bottom",
+                color="darkred",
+                fontweight="bold",
+                fontsize=14,
+            )
         if show_source_file:
             # place a text box in upper left in axes coords
             props = dict(boxstyle="round", facecolor="white", alpha=0.5)
@@ -283,11 +298,14 @@ def generic_graph(
     item_title: str,
     second_axis: MonitoringContextKeys | None = None,
     filter=None,
+    names=None,
+    dir_suffix=None,
+    title_note=None,
 ) -> int:
     outfile = f"{item_title}"
     trace = bench.get_trace()
 
-    components = bench.get_all_metrics(component_type, filter)
+    components = bench.get_all_metrics(component_type, filter, names)
     if not len(components):
         title = f"{item_title}: no {component_type!s} metric found"
         if filter:
@@ -302,14 +320,18 @@ def generic_graph(
     title = f'{item_title} during "{bench.get_bench_name()}" benchmark job\n{args.title}\n\n Stressor: '
     title += f"{bench.workers()} x {bench.get_title_engine_name()} for {bench.duration()} seconds"
     title += f"\n{bench.get_system_title()}"
+    graph_dir = output_dir.joinpath(f"{trace.get_name()}/{bench.get_bench_name()}/{component_type!s}")
+    if dir_suffix:
+        graph_dir = graph_dir.joinpath(dir_suffix)
     graph = Graph(
         args,
         title,
         "Time [seconds]",
         unit,
-        output_dir.joinpath(f"{trace.get_name()}/{bench.get_bench_name()}/{component_type!s}"),
+        graph_dir,
         outfile,
         show_source_file=trace,
+        title_note=title_note,
     )
 
     if second_axis:

--- a/graph/graph.py
+++ b/graph/graph.py
@@ -118,8 +118,6 @@ class Graph:
         # Keep a zero baseline so graphs stay comparable across CPUs/products,
         # but when no explicit ymax is given, push the top of the axis slightly
         # above the data so the highest curve is not merged with the frame.
-        # (dataLim is already kept current by plot()/add_collection; we avoid
-        # relim() which would drop LineCollection contributions.)
         if ymax is None:
             data_top = self.ax.dataLim.ymax
             if data_top and 0 < data_top < float("inf"):

--- a/graph/graph.py
+++ b/graph/graph.py
@@ -5,6 +5,7 @@ from itertools import cycle
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.collections import LineCollection
 from matplotlib.pylab import Axes
 from matplotlib.ticker import AutoMinorLocator, FuncFormatter, MultipleLocator
 
@@ -117,8 +118,9 @@ class Graph:
         # Keep a zero baseline so graphs stay comparable across CPUs/products,
         # but when no explicit ymax is given, push the top of the axis slightly
         # above the data so the highest curve is not merged with the frame.
+        # (dataLim is already kept current by plot()/add_collection; we avoid
+        # relim() which would drop LineCollection contributions.)
         if ymax is None:
-            self.ax.relim()
             data_top = self.ax.dataLim.ymax
             if data_top and 0 < data_top < float("inf"):
                 ymax = data_top * YMAX_HEADROOM
@@ -445,19 +447,38 @@ def generic_graph(
             y2_label = statistics_in_label(str(data2_item), y2_serie, max_title_length, max_value_length)
             graph.get_ax2().plot(x_serie, y2_serie, "", label=y2_label, marker=".")
 
-    max_title_length = max(len(component.get_full_name()) for component in components)
-    max_value_length = max(
-        get_max_value_string_length(np.array(data_serie[component.get_full_name()])) for component in components
-    )
-    for component in components:
-        y_serie = np.array(data_serie[component.get_full_name()])[order]
-        y_label = ""
-        # If we have more than 36 items to draw,
-        # labels will not fit and makes the drawing hard to read.
-        # Let's disable labels in such case.
-        if len(components) < 37:
+    # If we have more than 36 items to draw, labels will not fit and makes the
+    # drawing hard to read. In that case there is no legend, so we can draw all
+    # the lines as a single LineCollection: this is visually identical but much
+    # cheaper than creating one Line2D per component (e.g. 320 CPU cores).
+    if len(components) < 37:
+        max_title_length = max(len(component.get_full_name()) for component in components)
+        max_value_length = max(
+            get_max_value_string_length(np.array(data_serie[component.get_full_name()])) for component in components
+        )
+        for component in components:
+            y_serie = np.array(data_serie[component.get_full_name()])[order]
             y_label = statistics_in_label(component.get_full_name(), y_serie, max_title_length, max_value_length)
-        graph.get_ax().plot(x_serie, y_serie, "", label=y_label)
+            graph.get_ax().plot(x_serie, y_serie, "", label=y_label)
+    else:
+        segments = [
+            np.column_stack([x_serie, np.array(data_serie[component.get_full_name()])[order]])
+            for component in components
+        ]
+        # Reproduce the per-line color cycling matplotlib's plot() would apply.
+        cycle_colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+        colors = [cycle_colors[i % len(cycle_colors)] for i in range(len(segments))]
+        graph.get_ax().add_collection(
+            LineCollection(
+                segments,
+                colors=colors,
+                linewidths=plt.rcParams["lines.linewidth"],
+                capstyle=plt.rcParams["lines.solid_capstyle"],
+            )
+        )
+        # add_collection updates the data limits but, unlike plot(), does not
+        # refresh the view; do it so the axes autoscale to the data as usual.
+        graph.get_ax().autoscale_view()
 
     graph.prepare_axes(
         30,

--- a/graph/graph.py
+++ b/graph/graph.py
@@ -26,6 +26,11 @@ def init_matplotlib(args):
 
 GRAPH_TYPES = ["perf", "perf_watt", "watts", "cpu_clock"]
 
+# Extra headroom added above the data when no explicit ymax is provided, so the
+# top curve is not merged with the frame. Graphs stay zero-based (comparable
+# across CPUs/products); we only push the top of the axis a bit above the data.
+YMAX_HEADROOM = 1.05
+
 
 class Graph:
     def __init__(
@@ -109,6 +114,14 @@ class Graph:
                 MultipleLocator(y_minor),
             )
 
+        # Keep a zero baseline so graphs stay comparable across CPUs/products,
+        # but when no explicit ymax is given, push the top of the axis slightly
+        # above the data so the highest curve is not merged with the frame.
+        if ymax is None:
+            self.ax.relim()
+            data_top = self.ax.dataLim.ymax
+            if data_top and 0 < data_top < float("inf"):
+                ymax = data_top * YMAX_HEADROOM
         self.ax.set_ylim(None, ymin=0, ymax=ymax, emit=True, auto=True)
         # If we have a 2nd axis, let's prepare it
         if self.ax2:

--- a/graph/hwgraph.py
+++ b/graph/hwgraph.py
@@ -463,19 +463,38 @@ def graph_cpu(args, trace: Trace, bench_name: str, output_dir) -> int:
     cpu_graphs["Package power consumption"] = {MonitoringContextKeys.PowerConsumption: "package"}
     cpu_graphs["Core frequency"] = {MonitoringContextKeys.Freq: "Core"}
     cpu_graphs["Core IPC"] = {MonitoringContextKeys.IPC: "Core"}
+    # Per-core metrics (filter "Core") are rendered twice: once for all the
+    # cores of the system, once restricted to the cores that were pinned during
+    # this benchmark job. Each rendering lands in its own subdirectory so the
+    # two outputs never collide.
+    pinned_core_names = bench.pinned_core_names()
+
+    pinned_note = f"View limited to the pinned logical cores {bench.pinned_cpu_range()}"
+
     for graph_name in cpu_graphs:
         # Let's render the performance, perf_per_temp, perf_per_watt graphs
         for metric, filter in cpu_graphs[graph_name].items():
-            for second_axis in [None, MonitoringContextKeys.Thermal, MonitoringContextKeys.PowerConsumption]:
-                rendered_graphs += generic_graph(
-                    args,
-                    output_dir,
-                    bench,
-                    metric,
-                    graph_name,
-                    second_axis,
-                    filter=filter,
-                )
+            if filter == "Core":
+                renderings = [("all_cores", None, None)]  # type: list
+                if pinned_core_names:
+                    renderings.append(("pinned_cores", pinned_core_names, pinned_note))
+            else:
+                # Non per-core metrics (e.g. package power) keep a single rendering.
+                renderings = [(None, None, None)]
+            for dir_suffix, names, title_note in renderings:
+                for second_axis in [None, MonitoringContextKeys.Thermal, MonitoringContextKeys.PowerConsumption]:
+                    rendered_graphs += generic_graph(
+                        args,
+                        output_dir,
+                        bench,
+                        metric,
+                        graph_name,
+                        second_axis,
+                        filter=filter,
+                        names=names,
+                        dir_suffix=dir_suffix,
+                        title_note=title_note,
+                    )
 
     return rendered_graphs
 

--- a/graph/scaling.py
+++ b/graph/scaling.py
@@ -27,6 +27,12 @@ def smp_scaling_graph(args, output_dir, job: str, traces_name: list) -> int:
         aggregated_watt_err = {}  # type: dict[str, dict[str, Any]]
         aggregated_cpu_clock = {}  # type: dict[str, dict[str, Any]]
         aggregated_cpu_clock_err = {}  # type: dict[str, dict[str, Any]]
+        # Same as above but restricted to the cores pinned during each benchmark
+        aggregated_cpu_clock_pinned = {}  # type: dict[str, dict[str, Any]]
+        aggregated_cpu_clock_pinned_err = {}  # type: dict[str, dict[str, Any]]
+        # Whether at least one run of this sweep pinned cores (each run may pin a
+        # different set), used to decide if the pinned-cores graph is relevant.
+        any_pinned = False
         workers = {}  # type: dict[str, list]
         logical_core_per_worker = []
         perf_list, unit = benches[emp]["metrics"]
@@ -45,6 +51,8 @@ def smp_scaling_graph(args, output_dir, job: str, traces_name: list) -> int:
                 aggregated_watt_err[perf] = {}
                 aggregated_cpu_clock[perf] = {}
                 aggregated_cpu_clock_err[perf] = {}
+                aggregated_cpu_clock_pinned[perf] = {}
+                aggregated_cpu_clock_pinned_err[perf] = {}
             # For every trace file given at the command line
             for trace in args.traces:
                 workers[trace.get_name()] = []
@@ -69,6 +77,8 @@ def smp_scaling_graph(args, output_dir, job: str, traces_name: list) -> int:
                         aggregated_watt_err[perf][trace.get_name()] = []
                         aggregated_cpu_clock[perf][trace.get_name()] = []
                         aggregated_cpu_clock_err[perf][trace.get_name()] = []
+                        aggregated_cpu_clock_pinned[perf][trace.get_name()] = []
+                        aggregated_cpu_clock_pinned_err[perf][trace.get_name()] = []
 
                     bench.add_perf(
                         perf,
@@ -80,6 +90,17 @@ def smp_scaling_graph(args, output_dir, job: str, traces_name: list) -> int:
                         cpu_clock_err=aggregated_cpu_clock_err[perf][trace.get_name()],
                     )
 
+                    # Same cpu clock aggregation but averaging only the cores
+                    # pinned during this benchmark (falls back to all cores when
+                    # the benchmark has no pinning).
+                    bench.add_perf(
+                        cpu_clock=aggregated_cpu_clock_pinned[perf][trace.get_name()],
+                        cpu_clock_err=aggregated_cpu_clock_pinned_err[perf][trace.get_name()],
+                        cpu_clock_cores=bench.pinned_core_names(),
+                    )
+                    if bench.cpu_pin():
+                        any_pinned = True
+
         # Let's render all graphs types
         for graph_type in GRAPH_TYPES:
             # Let's render each performance graph
@@ -89,7 +110,8 @@ def smp_scaling_graph(args, output_dir, job: str, traces_name: list) -> int:
             for perf in perf_list:
                 clean_perf = perf.replace(" ", "").replace("/", "")
                 y_label = unit
-                outdir = temp_outdir.joinpath(graph_type)
+                # err_source is only set for graphs plotted with error bars.
+                err_source = None
                 if "perf_watt" in graph_type:
                     graph_type_title = f"SMP scaling {graph_type}: '{bench.get_title_engine_name()} / {args.traces[0].get_metric_name()}'"
                     y_label = f"{unit} per Watt"
@@ -100,95 +122,113 @@ def smp_scaling_graph(args, output_dir, job: str, traces_name: list) -> int:
                     outfile = f"scaling_watt_{clean_perf}_{bench.get_title_engine_name().replace(' ', '_')}"
                     y_label = "Watts"
                     y_source = aggregated_watt
+                    err_source = aggregated_watt_err
                 elif "cpu_clock" in graph_type:
                     graph_type_title = f"SMP scaling {graph_type}: {args.traces[0].get_metric_name()}"
                     outfile = f"scaling_cpu_clock_{clean_perf}_{bench.get_title_engine_name().replace(' ', '_')}"
                     y_label = "Mhz"
                     y_source = aggregated_cpu_clock
+                    err_source = aggregated_cpu_clock_err
                 else:
                     graph_type_title = f"SMP scaling {graph_type}: {bench.get_title_engine_name()}"
                     outfile = f"scaling_{clean_perf}_{bench.get_title_engine_name().replace(' ', '_')}"
                     y_source = aggregated_perfs
 
-                title = f'{args.title}\n\n{graph_type_title} via "{job}" benchmark job\n\n Stressor: '
-                title += f"{bench.get_title_engine_name()} for {bench.duration()} seconds"
-                xlabel = "Workers"
-                # If we have a constant ratio between cores & workers, let's report them under the Xaxis
-                if stdev(logical_core_per_worker) == 0:
-                    cores = "cores"
-                    if logical_core_per_worker[0] == 1:
-                        cores = "core"
-                    xlabel += f"\n({int(logical_core_per_worker[0])} logical {cores} per worker)"
-
-                graph = Graph(
-                    args,
-                    title,
-                    xlabel,
-                    y_label,
-                    outdir,
-                    outfile,
-                    square=True,
-                )
-
-                # Let's defined colors used during the rendering
-                # As we use error bars, let's ensure colors are readable with the error color.
-                colors = [
-                    "tab:blue",
-                    "tab:purple",
-                    "tab:green",
-                    "peru",
-                    "slategrey",
-                ]
-                e_colors = [
-                    "darkblue",
-                    "darkmagenta",
-                    "darkgreen",
-                    "tab:brown",
-                    "tab:grey",
-                ]
-                # Traces are not ordered by growing cpu cores count
-                # We need to prepare the x_serie to be sorted this way
-                # The y_serie depends on the graph type
-                for trace_name, color_name, e_color in zip(aggregated_perfs[perf], colors, cycle(e_colors)):
-                    # Each trace can have different numbers of workers based on the hardware setup
-                    # So let's consider the list of x values per trace.
-                    order = np.argsort(workers[trace_name])
-                    x_serie = np.array(workers[trace_name])[order]
-                    y_serie = np.array(y_source[perf][trace_name])[order]
-                    # If we plot the power consumption, let's use errorbars
-                    y_label = statistics_in_label(trace_name, y_serie)
-                    if y_source == aggregated_watt:
-                        graph.get_ax().errorbar(
-                            x_serie,
-                            y_serie,
-                            yerr=np.array(aggregated_watt_err[perf][trace_name]).T,
-                            ecolor=e_color,
-                            color=color_name,
-                            capsize=4,
-                            label=y_label,
+                # The cpu clock scaling graph is rendered twice: once averaging
+                # every system core, once averaging only the cores pinned during
+                # each benchmark. Each variant is stored in its own subdirectory
+                # so the two renderings never collide.
+                if "cpu_clock" in graph_type:
+                    variants = [
+                        ("all_cores", aggregated_cpu_clock, aggregated_cpu_clock_err, None),
+                    ]  # type: list
+                    # Only add the pinned-cores variant when at least one run of
+                    # the sweep actually pinned cores (otherwise it duplicates
+                    # the all-cores graph). Each scaling step pins its own set of
+                    # cores, so we don't list a single global range here.
+                    if any_pinned:
+                        pinned_note = "View limited to the pinned cores of each scaling step"
+                        variants.append(
+                            ("pinned_cores", aggregated_cpu_clock_pinned, aggregated_cpu_clock_pinned_err, pinned_note)
                         )
-                    elif y_source == aggregated_cpu_clock:
-                        graph.get_ax().errorbar(
-                            x_serie,
-                            y_serie,
-                            yerr=np.array(aggregated_cpu_clock_err[perf][trace_name]).T,
-                            ecolor=e_color,
-                            color=color_name,
-                            capsize=4,
-                            label=y_label,
-                        )
-                    else:
-                        graph.get_ax().plot(
-                            x_serie,
-                            y_serie,
-                            "",
-                            color=color_name,
-                            label=y_label,
-                            marker="o",
-                        )
+                else:
+                    variants = [(None, y_source, err_source, None)]
 
-                graph.prepare_axes(8, 4)
-                graph.render()
-                rendered_graphs += 1
+                for dir_suffix, v_y_source, v_err_source, note in variants:
+                    outdir = temp_outdir.joinpath(graph_type)
+                    if dir_suffix:
+                        outdir = outdir.joinpath(dir_suffix)
+
+                    title = f'{args.title}\n\n{graph_type_title} via "{job}" benchmark job\n\n Stressor: '
+                    title += f"{bench.get_title_engine_name()} for {bench.duration()} seconds"
+                    xlabel = "Workers"
+                    # If we have a constant ratio between cores & workers, let's report them under the Xaxis
+                    if stdev(logical_core_per_worker) == 0:
+                        cores = "cores"
+                        if logical_core_per_worker[0] == 1:
+                            cores = "core"
+                        xlabel += f"\n({int(logical_core_per_worker[0])} logical {cores} per worker)"
+
+                    graph = Graph(
+                        args,
+                        title,
+                        xlabel,
+                        y_label,
+                        outdir,
+                        outfile,
+                        square=True,
+                        title_note=note,
+                    )
+
+                    # Let's defined colors used during the rendering
+                    # As we use error bars, let's ensure colors are readable with the error color.
+                    colors = [
+                        "tab:blue",
+                        "tab:purple",
+                        "tab:green",
+                        "peru",
+                        "slategrey",
+                    ]
+                    e_colors = [
+                        "darkblue",
+                        "darkmagenta",
+                        "darkgreen",
+                        "tab:brown",
+                        "tab:grey",
+                    ]
+                    # Traces are not ordered by growing cpu cores count
+                    # We need to prepare the x_serie to be sorted this way
+                    # The y_serie depends on the graph type
+                    for trace_name, color_name, e_color in zip(aggregated_perfs[perf], colors, cycle(e_colors)):
+                        # Each trace can have different numbers of workers based on the hardware setup
+                        # So let's consider the list of x values per trace.
+                        order = np.argsort(workers[trace_name])
+                        x_serie = np.array(workers[trace_name])[order]
+                        y_serie = np.array(v_y_source[perf][trace_name])[order]
+                        series_label = statistics_in_label(trace_name, y_serie)
+                        # If we have an error distribution, let's use errorbars
+                        if v_err_source is not None:
+                            graph.get_ax().errorbar(
+                                x_serie,
+                                y_serie,
+                                yerr=np.array(v_err_source[perf][trace_name]).T,
+                                ecolor=e_color,
+                                color=color_name,
+                                capsize=4,
+                                label=series_label,
+                            )
+                        else:
+                            graph.get_ax().plot(
+                                x_serie,
+                                y_serie,
+                                "",
+                                color=color_name,
+                                label=series_label,
+                                marker="o",
+                            )
+
+                    graph.prepare_axes(8, 4)
+                    graph.render()
+                    rendered_graphs += 1
 
     return rendered_graphs

--- a/graph/trace.py
+++ b/graph/trace.py
@@ -228,7 +228,10 @@ class Bench:
         c = self.get_trace().get_cpu()
         k = self.get_trace().get_kernel()
         title = f"System: {d['serial']} {d['product']} Bios v{d['bios']['version']} Linux Kernel {k['release']}"
-        title += f"\nProcessor: {c['model']} with {c['physical_cores']} cores and {c['numa_domains']} NUMA domains"
+        title += (
+            f"\nProcessor: {c.get('sockets', 1)}x {c['model']} - "
+            f"{c['physical_cores']} physical cores and {c['numa_domains']} NUMA domains"
+        )
         return title
 
     def job_name(self) -> str:

--- a/graph/trace.py
+++ b/graph/trace.py
@@ -315,10 +315,13 @@ class Bench:
                     try:
                         effective_runtime = self.get("effective_runtime")
                         delta = abs(effective_runtime - self.duration())
-                        # The effective runtime must be within ~1sec compared to the expected duration
-                        if delta > 1:
+                        # The effective runtime must be within ~1sec compared to the expected duration.
+                        # add_perf() is called many times per bench, so only warn once.
+                        event_name = f"{self.trace.get_name()}/{self.get_bench_name()}"
+                        if delta > 1 and event_name not in self.trace.incomplete_runtime_reported:
+                            self.trace.incomplete_runtime_reported.add(event_name)
                             print(
-                                f"{self.trace.get_name()}/{self.get_bench_name()} didn't completed on time. "
+                                f"{event_name} didn't completed on time. "
                                 f"Effective_runtime={effective_runtime} vs {self.duration()} : delta=[{delta:.2f}s; {delta / self.duration() * 100:.2f}%]"
                             )
                     except TypeError:
@@ -480,6 +483,9 @@ class Trace:
         self.filename = filename
         self.logical_name = logical_name
         self.metric_name = metric_name
+        # Benchmarks already reported as not completing on time, so the warning
+        # is printed only once per bench instead of on every add_perf() call.
+        self.incomplete_runtime_reported: set = set()
         self.__load_file()
 
     def get_name(self) -> str:

--- a/graph/trace.py
+++ b/graph/trace.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import json
 import pathlib
@@ -15,6 +17,7 @@ from hwbench.bench.monitoring_structs import (
     PowerSuppliesContextKeys,
     Temperature,
 )
+from hwbench.utils.helpers import cpu_list_to_range
 
 EVENTS = "events"
 MIN = "min"
@@ -170,12 +173,20 @@ class Bench:
             return first_metric.get_unit()
         return None
 
-    def get_all_metrics(self, metric_type: MonitoringContextKeys, filter=None) -> list[MonitorMetric]:
-        """Return all metrics of a given type."""
+    def get_all_metrics(self, metric_type: MonitoringContextKeys, filter=None, names=None) -> list[MonitorMetric]:
+        """Return all metrics of a given type.
+
+        filter: substring that must be present in the component name (e.g. "Core").
+        names: if provided, an explicit allow-list of exact component names to keep
+               (e.g. {"Core_0", "Core_3"}); used to restrict rendering to the cores
+               pinned during a benchmark.
+        """
         metrics = []
         try:
             for metric in self.get_monitoring_metric(metric_type).values():
                 for component_name, component in metric.items():
+                    if names is not None and component_name not in names:
+                        continue
                     if not filter:
                         metrics.append(component)
                     else:
@@ -184,6 +195,25 @@ class Bench:
         except KeyError:
             pass
         return metrics
+
+    def pinned_core_names(self) -> set | None:
+        """Return the set of monitoring component names matching the pinned cores.
+
+        Returns None when the benchmark has no cpu pinning, so callers can fall
+        back to rendering every core.
+        """
+        cpu_pin = self.cpu_pin()
+        if not cpu_pin:
+            return None
+        return {f"Core_{core}" for core in cpu_pin}
+
+    def pinned_cpu_range(self) -> str:
+        """Return the pinned cpus as a condensed range string (e.g. '[0-12, 128-199]')."""
+        cpu_pin = self.cpu_pin()
+        if not cpu_pin:
+            return "[]"
+        # cpu_list_to_range sorts its argument in place, so pass a copy.
+        return f"[{cpu_list_to_range(list(cpu_pin))}]"
 
     def title(self) -> str:
         """Prepare the benchmark title name."""
@@ -265,6 +295,7 @@ class Bench:
         watt_err=None,
         cpu_clock=None,
         cpu_clock_err=None,
+        cpu_clock_cores=None,
         index=None,
     ) -> None:
         """Extract performance and power efficiency"""
@@ -357,8 +388,12 @@ class Bench:
                 for freq_metric in mm:
                     if freq_metric != "CPU":
                         continue
-                    # We have to compute metrics of all systems cores
+                    # By default we compute metrics over all the system cores.
+                    # When cpu_clock_cores is provided, we restrict the computation
+                    # to the cores that were pinned during this benchmark.
                     for core in mm[freq_metric]:
+                        if cpu_clock_cores is not None and core not in cpu_clock_cores:
+                            continue
                         # MIN of min ?
                         # Mean of mean ?
                         # Max of max ?

--- a/graph/versus.py
+++ b/graph/versus.py
@@ -20,9 +20,11 @@ def max_versus_graph(args, output_dir, job: str, traces_name: list) -> int:
         aggregated_perfs = {}  # type: dict[str, dict[str, Any]]
         aggregated_perfs_watt = {}  # type: dict[str, dict[str, Any]]
         aggregated_watt = {}  # type: dict[str, dict[str, Any]]
+        aggregated_cpu_clock = {}  # type: dict[str, dict[str, Any]]
         max_perf = {}  # type: dict[str, list]
         max_perfs_watt = {}  # type: dict[str, list]
         max_watt = {}  # type: dict[str, list]
+        max_cpu_clock = {}  # type: dict[str, list]
         max_workers = {}  # type: dict[str, list]
         perf_list, unit = benches[emp]["metrics"]
         # For each metric we need to plot
@@ -31,9 +33,11 @@ def max_versus_graph(args, output_dir, job: str, traces_name: list) -> int:
                 aggregated_perfs[perf] = {}
                 aggregated_perfs_watt[perf] = {}
                 aggregated_watt[perf] = {}
+                aggregated_cpu_clock[perf] = {}
                 max_perf[perf] = [0] * len(traces_name)
                 max_perfs_watt[perf] = [0] * len(traces_name)
                 max_watt[perf] = [0] * len(traces_name)
+                max_cpu_clock[perf] = [0] * len(traces_name)
                 max_workers[perf] = [0] * len(traces_name)
             # We want a datastructure where metrics of each iteration on the number of workers reports performance for each trace
             # It looks like :
@@ -58,11 +62,16 @@ def max_versus_graph(args, output_dir, job: str, traces_name: list) -> int:
                         aggregated_perfs[perf][bench.workers()] = [0] * len(traces_name)
                         aggregated_perfs_watt[perf][bench.workers()] = [0] * len(traces_name)
                         aggregated_watt[perf][bench.workers()] = [0] * len(traces_name)
+                        aggregated_cpu_clock[perf][bench.workers()] = [0] * len(traces_name)
                     bench.add_perf(
                         perf,
                         aggregated_perfs[perf][bench.workers()],
                         aggregated_perfs_watt[perf][bench.workers()],
                         aggregated_watt[perf][bench.workers()],
+                        cpu_clock=aggregated_cpu_clock[perf][bench.workers()],
+                        # Average the clock only over the cores pinned during the
+                        # benchmark (falls back to all cores when there is no pin).
+                        cpu_clock_cores=bench.pinned_core_names(),
                         index=index,
                     )
 
@@ -73,6 +82,7 @@ def max_versus_graph(args, output_dir, job: str, traces_name: list) -> int:
                         max_perf[perf][index] = temp_max_perf
                         max_perfs_watt[perf][index] = aggregated_perfs_watt[perf][bench.workers()][index]
                         max_watt[perf][index] = aggregated_watt[perf][bench.workers()][index]
+                        max_cpu_clock[perf][index] = aggregated_cpu_clock[perf][bench.workers()][index]
                         max_workers[perf][index] = bench.workers()
 
                 index = index + 1
@@ -103,6 +113,11 @@ def max_versus_graph(args, output_dir, job: str, traces_name: list) -> int:
                     graph_type_title += ": Lower is better"
                     y_label = "Watts"
                     y_max = max_watt
+                elif graph_type == "cpu_clock":
+                    # Clock of the pinned cores reached when the product hit its maximum performance.
+                    graph_type_title = f"Max versus '{graph_type}' on pinned cores: {bench.get_title_engine_name()}"
+                    y_label = "Mhz"
+                    y_max = max_cpu_clock
                 else:
                     graph_type_title = f"Max versus '{graph_type}': {bench.get_title_engine_name()}"
                     graph_type_title += ": Bigger is better"
@@ -113,7 +128,12 @@ def max_versus_graph(args, output_dir, job: str, traces_name: list) -> int:
                 # Now render the max performance graph
                 # Concept is to show what every product reached as a maximum perf and plot them together
                 # This way we have on a single graph showing the max of 32 cores vs a 48 cores vs a 64 cores.
-                for max_perf_type in ["max_perf_total", "max_perf_per_core"]:
+                # A per-core breakdown is meaningless for the CPU clock (it is
+                # already an average across cores), so only emit the total there.
+                max_perf_types = ["max_perf_total"]
+                if graph_type != "cpu_clock":
+                    max_perf_types.append("max_perf_per_core")
+                for max_perf_type in max_perf_types:
                     title = f'{args.title}\n\n{graph_type_title} during "{job}" benchmark\n'
                     if max_perf_type == "max_perf_per_core":
                         title += f"\nPer core maximum performance during {bench.duration()} seconds"
@@ -122,6 +142,9 @@ def max_versus_graph(args, output_dir, job: str, traces_name: list) -> int:
                         for ymax_nb in range(len(y_max[perf])):
                             y_max_per_core[ymax_nb] = y_max[perf][ymax_nb] / args.traces[ymax_nb].get_physical_cores()
                         y_serie = np.array(y_max_per_core)
+                    elif graph_type == "cpu_clock":
+                        title += f"\nClock reached at maximum performance during {bench.duration()} seconds"
+                        y_serie = np.array(y_max[perf])
                     else:
                         title += f"\nProduct maximum performance during {bench.duration()} seconds"
                         y_serie = np.array(y_max[perf])


### PR DESCRIPTION
This PR improves hwgraph by :
- add pinned-cores rendering for CPU frequency/IPC graphs
- keep headroom between the top curve and the frame
- stop the 2nd y-axis legend from overlapping the axis
- stop the source-file caption from spilling out of its box
- make the CPU package count explicit in the Processor header
- Improve rendering performance by ~25%
- max_versus do not render cpu_clocks but performance
- warn only once per bench about incomplete runtime
